### PR TITLE
fix(executor): clamp gas_left for fatal EVM errors (FIB-78)

### DIFF
--- a/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
@@ -133,6 +133,25 @@ bcos::executor_v1::EVMCResult bcos::executor_v1::makeErrorEVMCResult(crypto::Has
     protocol::TransactionStatus status, evmc_status_code evmStatus, int64_t gas,
     const std::string& errorInfo)
 {
+    int64_t gasLeft = gas;
+    switch (evmStatus)
+    {
+    case EVMC_OUT_OF_GAS:
+    case EVMC_INTERNAL_ERROR:
+    case EVMC_STACK_OVERFLOW:
+    case EVMC_STACK_UNDERFLOW:
+    case EVMC_INVALID_INSTRUCTION:
+    case EVMC_UNDEFINED_INSTRUCTION:
+    case EVMC_BAD_JUMP_DESTINATION:
+    case EVMC_INVALID_MEMORY_ACCESS:
+        gasLeft = 0;
+        break;
+    default:
+        break;
+    }
+    if (gasLeft < 0)
+        gasLeft = 0;
+
     bytes errorBytes;
     if (!errorInfo.empty())
     {
@@ -155,7 +174,7 @@ bcos::executor_v1::EVMCResult bcos::executor_v1::makeErrorEVMCResult(crypto::Has
 
     return EVMCResult{
         evmc_result{.status_code = evmStatus,
-            .gas_left = gas,
+            .gas_left = gasLeft,
             .gas_refund = 0,
             .output_data = output.release(),
             .output_size = outputSize,

--- a/transaction-executor/tests/TestEVMCResult.cpp
+++ b/transaction-executor/tests/TestEVMCResult.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(testMakeErrorEVMCResult)
             *hashImpl, TransactionStatus::OutOfGas, EVMC_OUT_OF_GAS, 100, errorInfo);
 
         BOOST_CHECK_EQUAL(result.status_code, EVMC_OUT_OF_GAS);
-        BOOST_CHECK_EQUAL(result.gas_left, 100);
+        BOOST_CHECK_EQUAL(result.gas_left, 0);  // gas clamped to 0 for EVMC_OUT_OF_GAS
         BOOST_CHECK_EQUAL(result.status, TransactionStatus::OutOfGas);
         BOOST_CHECK_GT(result.output_size, 0);
         BOOST_CHECK_NE(result.output_data, nullptr);
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(testMakeErrorEVMCResult)
             *hashImpl, TransactionStatus::OutOfStack, EVMC_STACK_OVERFLOW, 50, "");
 
         BOOST_CHECK_EQUAL(result.status_code, EVMC_STACK_OVERFLOW);
-        BOOST_CHECK_EQUAL(result.gas_left, 50);
+        BOOST_CHECK_EQUAL(result.gas_left, 0);  // gas clamped to 0 for EVMC_STACK_OVERFLOW
         BOOST_CHECK_EQUAL(result.status, TransactionStatus::OutOfStack);
         BOOST_CHECK_GT(result.output_size, 0);
         BOOST_CHECK_NE(result.output_data, nullptr);
@@ -446,6 +446,42 @@ BOOST_AUTO_TEST_CASE(testResourceManagement)
 
         // Only result2 should clean up the data when destructed
     }
+}
+
+BOOST_AUTO_TEST_CASE(makeErrorEVMCResult_outOfGas_zeroGasLeft)
+{
+    auto result =
+        makeErrorEVMCResult(*hashImpl, TransactionStatus::OutOfGas, EVMC_OUT_OF_GAS, 100000, "");
+
+    BOOST_CHECK_EQUAL(result.status_code, EVMC_OUT_OF_GAS);
+    BOOST_CHECK_EQUAL(result.gas_left, 0);
+}
+
+BOOST_AUTO_TEST_CASE(makeErrorEVMCResult_revert_preservesGas)
+{
+    auto result = makeErrorEVMCResult(
+        *hashImpl, TransactionStatus::RevertInstruction, EVMC_REVERT, 50000, "");
+
+    BOOST_CHECK_EQUAL(result.status_code, EVMC_REVERT);
+    BOOST_CHECK_EQUAL(result.gas_left, 50000);
+}
+
+BOOST_AUTO_TEST_CASE(makeErrorEVMCResult_internalError_zeroGasLeft)
+{
+    auto result =
+        makeErrorEVMCResult(*hashImpl, TransactionStatus::Unknown, EVMC_INTERNAL_ERROR, 100000, "");
+
+    BOOST_CHECK_EQUAL(result.status_code, EVMC_INTERNAL_ERROR);
+    BOOST_CHECK_EQUAL(result.gas_left, 0);
+}
+
+BOOST_AUTO_TEST_CASE(makeErrorEVMCResult_negativeGas_clampedToZero)
+{
+    auto result =
+        makeErrorEVMCResult(*hashImpl, TransactionStatus::RevertInstruction, EVMC_REVERT, -100, "");
+
+    BOOST_CHECK_EQUAL(result.status_code, EVMC_REVERT);
+    BOOST_CHECK_EQUAL(result.gas_left, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
FIB-78: clamp gas_left to 0 for fatal EVM error statuses in makeErrorEVMCResult. Added unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to `makeErrorEVMCResult` error-path gas accounting plus added unit test coverage; main risk is behavior change for consumers that previously relied on non-zero `gas_left` on fatal failures.
> 
> **Overview**
> **Fixes gas accounting for fatal EVM failures.** `makeErrorEVMCResult` now forces `gas_left` to `0` for fatal EVMC statuses (e.g., out-of-gas, internal error, stack/opcode/memory/jump errors) and clamps any negative gas to `0`, while preserving gas for non-fatal statuses like `EVMC_REVERT`.
> 
> **Tests updated/added** to assert the new clamping behavior and cover revert/negative-gas cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f1fb7b10a127277b5d2ab060c4d39043e499a4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->