### PR TITLE
fix(scheduler): track DIRECT reads, fix single-pass range consumption, defer write tracking (FIB-100, FIB-106, FIB-109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ tools/BcosAirBuilder/*
 
 test/*
 /CMakeSettings.json
+
+# Claude Code
+CLAUDE.local.md
+.claude/worktrees
+.claude/agents

--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -13,6 +13,7 @@
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/throw_exception.hpp>
+#include <concepts>
 #include <optional>
 #include <range/v3/view/chunk_by.hpp>
 #include <range/v3/view/transform.hpp>
@@ -346,6 +347,32 @@ public:
         Lock lock(bucket.mutex, true);
         return {
             storage.writeOne(bucket, std::move(key), std::move(value), false, /*insertOnly=*/true)};
+    }
+
+    friend task::AwaitableValue<bool> tag_invoke(storage2::tag_t<storage2::writeOneIf> /*unused*/,
+        MemoryStorage& storage, auto key, auto value, std::predicate<Value const&> auto predicate)
+    {
+        auto& bucket = storage.getBucket(key);
+        [[maybe_unused]] Lock lock(bucket.mutex, true);
+
+        // Read existing value and evaluate predicate under the same lock
+        auto const& index = bucket.container.template get<0>();
+        bool shouldWrite = true;
+        if (auto it = index.find(key); it != index.end())
+        {
+            shouldWrite = std::visit(bcos::overloaded{[](DELETED_TYPE) { return true; },
+                                         [](NOT_EXISTS_TYPE) { return true; },
+                                         [&](Value const& itValue) { return predicate(itValue); }},
+                it->value);
+        }
+
+        if (!shouldWrite)
+        {
+            return {false};
+        }
+
+        storage.writeOne(bucket, std::move(key), std::move(value), false);
+        return {true};
     }
 
     friend task::AwaitableValue<void> tag_invoke(storage2::tag_t<storage2::writeSome> /*unused*/,

--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -220,7 +220,8 @@ public:
         }) | ::ranges::to<std::vector>();
     }
 
-    void writeOne(Bucket& bucket, auto key, auto value, bool ignoreLogicalDeletion)
+    bool writeOne(
+        Bucket& bucket, auto key, auto value, bool ignoreLogicalDeletion, bool insertOnly = false)
     {
         auto const& index = bucket.container.template get<0>();
         int64_t updatedCapacity = 0;
@@ -245,6 +246,10 @@ public:
 
         if (found)
         {
+            if (insertOnly)
+            {
+                return false;
+            }
             if (!deleteOP || (withLogicalDeletion && !ignoreLogicalDeletion))
             {
                 bucket.container.modify(it, [&](Data& data) mutable {
@@ -286,6 +291,7 @@ public:
             bucket.capacity += updatedCapacity;
             updateLRUAndCheck(bucket, it);
         }
+        return !found;
     }
 
     void removeSome(::ranges::input_range auto keys, bool ignoreLogicalDeletion)
@@ -330,6 +336,16 @@ public:
         Lock lock(bucket.mutex, true);
         storage.writeOne(bucket, std::move(key), std::move(value), false);
         return {};
+    }
+
+    friend task::AwaitableValue<bool> tag_invoke(
+        storage2::tag_t<storage2::insertIfAbsent> /*unused*/, MemoryStorage& storage, auto key,
+        auto value)
+    {
+        auto& bucket = storage.getBucket(key);
+        Lock lock(bucket.mutex, true);
+        return {
+            storage.writeOne(bucket, std::move(key), std::move(value), false, /*insertOnly=*/true)};
     }
 
     friend task::AwaitableValue<void> tag_invoke(storage2::tag_t<storage2::writeSome> /*unused*/,

--- a/bcos-framework/bcos-framework/storage2/Storage.h
+++ b/bcos-framework/bcos-framework/storage2/Storage.h
@@ -132,6 +132,15 @@ inline constexpr struct ExistsOne
     }
 } existsOne;
 
+inline constexpr struct InsertIfAbsent
+{
+    auto operator()(auto& storage, auto key, auto value, auto&&... args) const -> task::Task<bool>
+    {
+        co_return co_await tag_invoke(*this, storage, std::move(key), std::move(value),
+            std::forward<decltype(args)>(args)...);
+    }
+} insertIfAbsent;
+
 inline constexpr struct Merge
 {
     auto operator()(auto& toStorage, auto& fromStorage, auto&&... args) const -> task::Task<void>

--- a/bcos-framework/bcos-framework/storage2/Storage.h
+++ b/bcos-framework/bcos-framework/storage2/Storage.h
@@ -106,6 +106,20 @@ inline constexpr struct WriteOne
     }
 } writeOne;
 
+inline constexpr struct WriteOneIf
+{
+    // Atomically reads existing value, writes only if predicate(existing) is true.
+    // If no existing value, writes unconditionally.
+    // Predicate: (Value const&) -> bool
+    // Returns true if the write was performed.
+    auto operator()(auto& storage, auto key, auto value, auto predicate, auto&&... args) const
+        -> task::Task<bool>
+    {
+        co_return co_await tag_invoke(*this, storage, std::move(key), std::move(value),
+            std::move(predicate), std::forward<decltype(args)>(args)...);
+    }
+} writeOneIf;
+
 inline constexpr struct RemoveOne
 {
     auto operator()(auto& storage, auto key, auto&&... args) const -> task::Task<void>

--- a/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
@@ -534,4 +534,42 @@ BOOST_AUTO_TEST_CASE(dirtctReadOne)
     }());
 }
 
+BOOST_AUTO_TEST_CASE(writeOneIf)
+{
+    task::syncWait([]() -> task::Task<void> {
+        MemoryStorage<int, int, Attribute(CONCURRENT | LRU)> storage(4, 1024);
+
+        // 1. Write to non-existent key: no existing value, writes unconditionally
+        auto written = co_await storage2::writeOneIf(
+            storage, 1, 100, [](int const& existing) { return 100 > existing; });
+        BOOST_CHECK(written);
+        auto val = co_await storage2::readOne(storage, 1);
+        BOOST_REQUIRE(val.has_value());
+        BOOST_CHECK_EQUAL(*val, 100);
+
+        // 2. Conditional update: new > existing, should succeed
+        written = co_await storage2::writeOneIf(
+            storage, 1, 200, [](int const& existing) { return 200 > existing; });
+        BOOST_CHECK(written);
+        val = co_await storage2::readOne(storage, 1);
+        BOOST_REQUIRE(val.has_value());
+        BOOST_CHECK_EQUAL(*val, 200);
+
+        // 3. Conditional update rejected: 50 < 200, should fail
+        written = co_await storage2::writeOneIf(
+            storage, 1, 50, [](int const& existing) { return 50 > existing; });
+        BOOST_CHECK(!written);
+        val = co_await storage2::readOne(storage, 1);
+        BOOST_REQUIRE(val.has_value());
+        BOOST_CHECK_EQUAL(*val, 200);  // unchanged
+
+        // 4. Equal value with >= predicate, should succeed
+        written = co_await storage2::writeOneIf(
+            storage, 1, 200, [](int const& existing) { return 200 >= existing; });
+        BOOST_CHECK(written);
+
+        co_return;
+    }());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/bcos-txpool/txpool/interfaces/NonceCheckerInterface.h
+++ b/bcos-txpool/bcos-txpool/txpool/interfaces/NonceCheckerInterface.h
@@ -43,7 +43,9 @@ public:
     virtual void batchRemove(bcos::protocol::NonceList const& _nonceList) = 0;
     virtual void batchRemove(tbb::concurrent_unordered_set<bcos::protocol::NonceType,
         std::hash<bcos::protocol::NonceType>> const& _nonceList) = 0;
-    virtual void insert(bcos::protocol::NonceType const& _nonce) = 0;
+    // Returns true if the nonce was newly inserted, false if it already existed.
+    // Callers should treat false as NonceCheckFail (atomic check-and-reserve, FIB-51).
+    virtual bool insert(bcos::protocol::NonceType const& _nonce) = 0;
 
     virtual void remove(bcos::protocol::NonceType const& _nonce) = 0;
 };

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -330,6 +330,27 @@ TransactionStatus MemoryStorage::verifyAndSubmitTransaction(
     // Define remaining validation steps as a chain
     // Each step returns TransactionStatus::None if validation passes, or an error status otherwise
     const std::vector<std::function<TransactionStatus()>> validationSteps = {
+        [this, transaction, &txSubmitCallback]() {
+            // Step 1: Check if transaction already exists in txpool
+            auto result = txpoolStorageCheck(*transaction, txSubmitCallback);
+            if (result == TransactionStatus::AlreadyInTxPoolAndAccept) [[unlikely]]
+            {
+                // Note: if rpc is slower than p2p tx sync, we also need to accept this tx and
+                // record callback
+                return TransactionStatus::None;
+            }
+            return result;
+        },
+        [this, checkPoolLimit]() {
+            // Step 1.5: Enforce pool size limit before running expensive validation steps (FIB-55)
+            if (checkPoolLimit &&
+                (m_bcosTransactions.unsealTransactions.size() +
+                    m_bcosTransactions.sealedTransactions.size()) >= m_config->poolLimit())
+            {
+                return TransactionStatus::TxPoolIsFull;
+            }
+            return TransactionStatus::None;
+        },
         [this, transaction]() {
             // Step 2: Verify transaction signature (if enabled)
             return m_config->checkTransactionSignature() ?

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -362,7 +362,20 @@ TransactionStatus MemoryStorage::verifyAndSubmitTransaction(
         }
     }
 
-    // All validations passed, prepare for insertion
+    // All validations passed — now insert nonce atomically before inserting the transaction.
+    // Nonce insertion is done here (not inside verify()) so that failures in validateTransaction()
+    // or validateChainId() cannot leave a stale nonce in the pool (FIB-50).
+    if (m_config->checkTransactionSignature())
+    {
+        m_config->txPoolNonceChecker()->insert(std::string(transaction->nonce()));
+        if (transaction->type() == static_cast<uint8_t>(TransactionType::Web3Transaction))
+        {
+            task::syncWait(m_config->txValidator()->web3NonceChecker()->insertMemoryNonce(
+                std::string(transaction->sender()), std::string(transaction->nonce())));
+        }
+    }
+
+    // Prepare for insertion
     auto const txImportTime = transaction->importTime();
     if (txSubmitCallback)
     {

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -936,7 +936,8 @@ bool MemoryStorage::batchMarkTxs(crypto::HashListView _txsHashList, BlockNumber 
             successCount += localSuccess;
             notFound += localNotFound;
             reSealed += localReSealed;
-            if (localKnownLatestSealedTxIndex > 0)
+            // FIB-65: sentinel is -1; index 0 is valid, so use >= 0 not > 0
+            if (localKnownLatestSealedTxIndex >= 0)
             {
                 auto current = knownLatestSealedTxIndex.load();
                 while (localKnownLatestSealedTxIndex > current &&
@@ -946,7 +947,8 @@ bool MemoryStorage::batchMarkTxs(crypto::HashListView _txsHashList, BlockNumber 
                 }
             }
         });
-    if (knownLatestSealedTxIndex > 0)
+    // FIB-65: sentinel is -1; index 0 is valid, so use >= 0 not > 0
+    if (knownLatestSealedTxIndex >= 0)
     {
         m_knownLatestSealedTxHash = _txsHashList[knownLatestSealedTxIndex];
     }

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -654,7 +654,11 @@ bool MemoryStorage::batchSealTransactions(std::vector<protocol::TransactionMetaD
             return false;
         }
 
-        if (currentTime > (tx->importTime() + m_txsExpirationTime))
+        // Treat a negative importTime as already expired to prevent unsigned overflow when
+        // adding a negative int64_t to uint64_t m_txsExpirationTime (FIB-61)
+        auto const importTime = tx->importTime();
+        if (importTime < 0 ||
+            currentTime > (static_cast<uint64_t>(importTime) + m_txsExpirationTime))
         {
             invalidTxs.emplace_back(tx);
             return false;

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -390,13 +390,26 @@ TransactionStatus MemoryStorage::verifyAndSubmitTransaction(
     // All validations passed — now insert nonce atomically before inserting the transaction.
     // Nonce insertion is done here (not inside verify()) so that failures in validateTransaction()
     // or validateChainId() cannot leave a stale nonce in the pool (FIB-50).
+    // Atomic check-and-reserve: insert() returns false when the nonce already exists,
+    // eliminating the TOCTOU window between separate checkNonce() + insert() calls (FIB-51).
     if (m_config->checkTransactionSignature())
     {
-        m_config->txPoolNonceChecker()->insert(std::string(transaction->nonce()));
-        if (transaction->type() == static_cast<uint8_t>(TransactionType::Web3Transaction))
+        if (transaction->type() != static_cast<uint8_t>(TransactionType::Web3Transaction))
         {
-            task::syncWait(m_config->txValidator()->web3NonceChecker()->insertMemoryNonce(
-                std::string(transaction->sender()), std::string(transaction->nonce())));
+            if (!m_config->txPoolNonceChecker()->insert(std::string(transaction->nonce())))
+                [[unlikely]]
+            {
+                return TransactionStatus::NonceCheckFail;
+            }
+        }
+        else
+        {
+            if (!task::syncWait(m_config->txValidator()->web3NonceChecker()->insertMemoryNonce(
+                    std::string(transaction->sender()), std::string(transaction->nonce()))))
+                [[unlikely]]
+            {
+                return TransactionStatus::NonceCheckFail;
+            }
         }
     }
 

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -848,10 +848,13 @@ bool MemoryStorage::batchMarkTxs(crypto::HashListView _txsHashList, BlockNumber 
             {
                 auto hash = _txsHashList[index];
                 protocol::Transaction::Ptr transaction;
+                // Track whether the tx came from fromMap; only record for movement if it passes
+                // the re-seal guard below — prevents stranding re-sealed txs (FIB-60)
+                bool foundInFromMap = false;
                 if (bucket.find(accessor, hash))
                 {
                     transaction = accessor.value();
-                    moveTransactions[index] = transaction;
+                    foundInFromMap = true;
                 }
                 else if (TxsMap::ReadAccessor toAccessor;
                     toMap->find<TxsMap::ReadAccessor>(toAccessor, hash))
@@ -870,6 +873,12 @@ bool MemoryStorage::batchMarkTxs(crypto::HashListView _txsHashList, BlockNumber 
                 {
                     ++localReSealed;
                     continue;
+                }
+
+                // Assign to moveTransactions only after the re-seal guard passes
+                if (foundInFromMap)
+                {
+                    moveTransactions[index] = transaction;
                 }
 
                 transaction->setSealed(_sealFlag);

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -205,17 +205,43 @@ TransactionStatus MemoryStorage::txpoolStorageCheck(
     const Transaction& transaction, protocol::TxSubmitCallback& txSubmitCallback)
 {
     auto hash = transaction.hash();
-    if (TxsMap::ReadAccessor accessor;
-        m_bcosTransactions.unsealTransactions.find<TxsMap::ReadAccessor>(accessor, hash) ||
-        m_bcosTransactions.sealedTransactions.find<TxsMap::ReadAccessor>(accessor, hash))
-    {
-        if (txSubmitCallback && !accessor.value()->submitCallback())
+
+    // Per-map double-checked lookup: ReadAccessor (shared lock) first, upgrade to
+    // exclusive lock only when mutation is needed.  Each map uses its own accessor
+    // so the correct bucket lock is held.
+    auto checkMap = [&](auto& txMap) -> std::optional<TransactionStatus> {
+        // Fast path: shared (read) lock
+        TxsMap::ReadAccessor readAccessor;
+        if (!txMap.find(readAccessor, hash))
         {
-            accessor.value()->setSubmitCallback(std::move(txSubmitCallback));
-            return TransactionStatus::AlreadyInTxPoolAndAccept;
+            return std::nullopt;  // not in this map
+        }
+        if (!txSubmitCallback || readAccessor.value()->submitCallback())
+        {
+            return TransactionStatus::AlreadyInTxPool;  // no mutation needed
         }
 
-        return TransactionStatus::AlreadyInTxPool;
+        // Slow path: upgrade read lock -> write lock in-place
+        if (!readAccessor.upgradeToWriter() && !readAccessor.revalidate(hash))
+        {
+            return std::nullopt;  // tx removed during non-atomic upgrade
+        }
+        // Double-check under exclusive lock
+        if (!readAccessor.value()->submitCallback())
+        {
+            readAccessor.value()->setSubmitCallback(std::move(txSubmitCallback));
+            return TransactionStatus::AlreadyInTxPoolAndAccept;
+        }
+        return TransactionStatus::AlreadyInTxPool;  // another thread set it first
+    };
+
+    if (const auto result = checkMap(m_bcosTransactions.unsealTransactions))
+    {
+        return *result;
+    }
+    if (const auto result = checkMap(m_bcosTransactions.sealedTransactions))
+    {
+        return *result;
     }
     return TransactionStatus::None;
 }
@@ -715,7 +741,9 @@ bool MemoryStorage::batchSealTransactions(std::vector<protocol::TransactionMetaD
         return true;
     };
 
-    for (auto& accessor : m_bcosTransactions.unsealTransactions.rangeByKey<TxsMap::ReadAccessor>(
+    // Use WriteAccessor so that mutations inside handleTx (setSealed, setBatchId, setBatchHash)
+    // are performed under an exclusive bucket lock (FIB-54)
+    for (auto& accessor : m_bcosTransactions.unsealTransactions.rangeByKey<TxsMap::WriteAccessor>(
              m_knownLatestSealedTxHash))
     {
         const auto& tx = accessor.value();
@@ -876,8 +904,11 @@ bool MemoryStorage::batchMarkTxs(crypto::HashListView _txsHashList, BlockNumber 
     TxsMap* toMap = _sealFlag ? std::addressof(m_bcosTransactions.sealedTransactions) :
                                 std::addressof(m_bcosTransactions.unsealTransactions);
     std::vector<Transaction::Ptr> moveTransactions(_txsHashList.size());
-    fromMap->traverse<TxsMap::ReadAccessor, true>(
-        _txsHashList, [&](TxsMap::ReadAccessor& accessor, const auto& range, auto& bucket) {
+    // Use WriteAccessor so that mutations to transaction fields (setSealed, setBatchId,
+    // setBatchHash) are performed under an exclusive bucket lock, preventing data races
+    // with concurrent readers of the same bucket (FIB-54)
+    fromMap->traverse<TxsMap::WriteAccessor, true>(
+        _txsHashList, [&](TxsMap::WriteAccessor& accessor, const auto& range, auto& bucket) {
             size_t localNotFound = 0;
             size_t localReSealed = 0;
             size_t localSuccess = 0;

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -312,20 +312,24 @@ TransactionStatus MemoryStorage::verifyAndSubmitTransaction(
     ittapi::Report report(
         ittapi::ITT_DOMAINS::instance().TXPOOL, ittapi::ITT_DOMAINS::instance().SUBMIT_TX);
 
-    // Define validation steps as a chain of validators
+    // Step 1: Check if transaction already exists in txpool
+    {
+        auto result = txpoolStorageCheck(*transaction, txSubmitCallback);
+        if (result == TransactionStatus::AlreadyInTxPoolAndAccept) [[unlikely]]
+        {
+            // Callback has been moved to the existing transaction; return success immediately
+            // without proceeding to insert() to avoid use-after-free and double-resume (FIB-48)
+            return TransactionStatus::None;
+        }
+        if (result != TransactionStatus::None)
+        {
+            return result;
+        }
+    }
+
+    // Define remaining validation steps as a chain
     // Each step returns TransactionStatus::None if validation passes, or an error status otherwise
     const std::vector<std::function<TransactionStatus()>> validationSteps = {
-        [this, transaction, &txSubmitCallback]() {
-            // Step 1: Check if transaction already exists in txpool
-            auto result = txpoolStorageCheck(*transaction, txSubmitCallback);
-            if (result == TransactionStatus::AlreadyInTxPoolAndAccept) [[unlikely]]
-            {
-                // Note: if rpc is slower than p2p tx sync, we also need to accept this tx and
-                // record callback
-                return TransactionStatus::None;
-            }
-            return result;
-        },
         [this, transaction]() {
             // Step 2: Verify transaction signature (if enabled)
             return m_config->checkTransactionSignature() ?

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.cpp
@@ -40,10 +40,13 @@ TransactionStatus TxPoolNonceChecker::checkNonce(const bcos::protocol::Transacti
     return TransactionStatus::None;
 }
 
-void TxPoolNonceChecker::insert(NonceType const& _nonce)
+bool TxPoolNonceChecker::insert(NonceType const& _nonce)
 {
     NonceSet::WriteAccessor accessor;
-    m_nonces.insert(accessor, _nonce);
+    // BucketSet::insert returns true if newly inserted, false if already existed.
+    // This makes check-and-reserve atomic: callers that get false must treat it as
+    // NonceCheckFail without an intermediate checkNonce() call (FIB-51).
+    return m_nonces.insert(accessor, _nonce);
 }
 
 void TxPoolNonceChecker::batchInsert(BlockNumber /*_batchId*/, NonceListPtr const& _nonceList)

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.h
@@ -36,7 +36,7 @@ public:
         std::hash<bcos::protocol::NonceType>> const& _nonceList) override;
     bool exists(bcos::protocol::NonceType const& _nonce) override;
 
-    void insert(bcos::protocol::NonceType const& _nonce) override;
+    bool insert(bcos::protocol::NonceType const& _nonce) override;
 
 protected:
     void remove(bcos::protocol::NonceType const& _nonce) override;

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -83,12 +83,9 @@ TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
     {
         _tx.setSystemTx(true);
     }
-    m_txPoolNonceChecker->insert(std::string(_tx.nonce()));
-    if (_tx.type() == static_cast<uint8_t>(TransactionType::Web3Transaction))
-    {
-        task::syncWait(m_web3NonceChecker->insertMemoryNonce(
-            std::string(_tx.sender()), std::string(_tx.nonce())));
-    }
+    // Nonce insertion is deferred to after all validation steps complete in
+    // verifyAndSubmitTransaction(), so that a failure in validateTransaction() or
+    // validateChainId() does not leave a leaked nonce in the pool (FIB-50)
     return TransactionStatus::None;
 }
 

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -55,7 +55,7 @@ task::Task<bcos::protocol::TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
     // obtained from the rpc api by the web3 tool is 5; then the new transaction will be sent
     // from 5.
     if (!onlyCheckLedgerNonce &&
-        co_await bcos::storage2::existsOne(m_memoryNonces, std::make_pair(sender, nonce)))
+        co_await bcos::storage2::existsOne(m_memoryNonces, std::make_pair(sender, nonceU256)))
     {
         // memory nonce check nonce existence in memory first, if not exist, then check from storage
         TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: nonce mem check fail")
@@ -105,21 +105,22 @@ task::Task<TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
 
 task::Task<bool> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)
 {
+    auto const uNonce = u256(nonce);
     if (c_fileLogLevel == TRACE) [[unlikely]]
     {
         TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: write memory nonces")
-                          << LOG_KV("sender", toHex(sender)) << LOG_KV("nonce", nonce);
+                          << LOG_KV("sender", toHex(sender)) << LOG_KV("nonce", uNonce);
     }
     // Atomic check-and-reserve: insertIfAbsent returns false when the (sender, nonce)
     // pair already exists, eliminating the TOCTOU race between existsOne() and writeOne().
     if (const bool inserted = co_await storage2::insertIfAbsent(
-            m_memoryNonces, std::make_pair(sender, nonce), std::monostate{});
+            m_memoryNonces, std::make_pair(sender, uNonce), std::monostate{});
         !inserted)
     {
         co_return false;
     }
     const auto maxMemNonce = co_await storage2::readOne(m_maxNonces, sender);
-    if (auto const uNonce = u256(nonce); !maxMemNonce.has_value() || uNonce >= maxMemNonce.value())
+    if (!maxMemNonce.has_value() || uNonce >= maxMemNonce.value())
     {
         if (c_fileLogLevel == TRACE) [[unlikely]]
         {

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -32,6 +32,17 @@ using namespace bcos::protocol;
 task::Task<bcos::protocol::TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
     std::string_view sender, std::string_view nonce, bool onlyCheckLedgerNonce)
 {
+    // Reject oversized nonce strings before any u256 conversion to prevent LRU capacity bypass
+    // (FIB-57): max decimal digits of u256 is 78
+    constexpr static size_t MAX_NONCE_STRING_LENGTH = 78;
+    if (nonce.length() > MAX_NONCE_STRING_LENGTH) [[unlikely]]
+    {
+        TXPOOL_LOG(WARNING) << LOG_DESC("Web3Nonce: reject oversized nonce string")
+                            << LOG_KV("sender", toHex(sender))
+                            << LOG_KV("nonceLen", nonce.length());
+        co_return TransactionStatus::NonceCheckFail;
+    }
+
     // sender is bytes view
     auto const senderHex = toHex(sender);
     auto nonceU256 = u256(nonce);

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -103,14 +103,21 @@ task::Task<TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
     co_return co_await checkWeb3Nonce(_tx.sender(), _tx.nonce(), onlyCheckLedgerNonce);
 }
 
-task::Task<void> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)
+task::Task<bool> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)
 {
     if (c_fileLogLevel == TRACE) [[unlikely]]
     {
         TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: write memory nonces")
                           << LOG_KV("sender", toHex(sender)) << LOG_KV("nonce", nonce);
     }
-    co_await storage2::writeOne(m_memoryNonces, std::make_pair(sender, nonce), std::monostate{});
+    // Atomic check-and-reserve: insertIfAbsent returns false when the (sender, nonce)
+    // pair already exists, eliminating the TOCTOU race between existsOne() and writeOne().
+    if (const bool inserted = co_await storage2::insertIfAbsent(
+            m_memoryNonces, std::make_pair(sender, nonce), std::monostate{});
+        !inserted)
+    {
+        co_return false;
+    }
     const auto maxMemNonce = co_await storage2::readOne(m_maxNonces, sender);
     if (auto const uNonce = u256(nonce); !maxMemNonce.has_value() || uNonce >= maxMemNonce.value())
     {
@@ -123,6 +130,7 @@ task::Task<void> Web3NonceChecker::insertMemoryNonce(std::string sender, std::st
         }
         co_await storage2::writeOne(m_maxNonces, sender, uNonce + 1);
     }
+    co_return true;
 }
 
 task::Task<std::optional<u256>> Web3NonceChecker::getPendingNonce(std::string_view sender)

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -63,10 +63,13 @@ task::Task<bcos::protocol::TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
         co_return TransactionStatus::NonceCheckFail;
     }
 
+    // Check ledger state nonce cache first; only query the ledger storage on a cache miss to avoid
+    // unconditional expensive I/O on every tx submission (FIB-59)
     if (auto const nonceInLedger = co_await bcos::storage2::readOne(m_ledgerStateNonces, sender))
     {
-        if (auto nonceInLedgerValue = nonceInLedger.value();
-            nonceU256 < nonceInLedgerValue ||
+        // Cache hit: validate against cached value and return without touching storage
+        auto nonceInLedgerValue = nonceInLedger.value();
+        if (nonceU256 < nonceInLedgerValue ||
             nonceU256 > nonceInLedgerValue + DEFAULT_WEB3_NONCE_CHECK_LIMIT)
         {
             TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: nonce ledger check fail")
@@ -74,16 +77,18 @@ task::Task<bcos::protocol::TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
                               << LOG_KV("nonceInLedger", nonceInLedgerValue);
             co_return TransactionStatus::NonceCheckFail;
         }
+        co_return TransactionStatus::None;
     }
-    // not in ledger memory, check from storage
-    // TODO)): block number not use nowadays
+
+    // Cache miss: query ledger storage
     if (auto const storageState = co_await m_ledger->getStorageState(senderHex, 0);
         storageState.has_value())
     {
         // nonce in storage is uint string
         auto const nonceInStorage = u256(storageState.value().nonce);
-        // update memory first
-        co_await storage2::writeOne(m_ledgerStateNonces, sender, nonceInStorage);
+        // Monotonic cache update: only raise the cached value, never lower it (FIB-59)
+        co_await storage2::writeOneIf(m_ledgerStateNonces, sender, nonceInStorage,
+            [&](u256 const& existing) { return nonceInStorage > existing; });
         if (nonceU256 < nonceInStorage ||
             nonceU256 > nonceInStorage + DEFAULT_WEB3_NONCE_CHECK_LIMIT)
         {
@@ -119,17 +124,13 @@ task::Task<bool> Web3NonceChecker::insertMemoryNonce(std::string sender, std::st
     {
         co_return false;
     }
-    const auto maxMemNonce = co_await storage2::readOne(m_maxNonces, sender);
-    if (!maxMemNonce.has_value() || uNonce >= maxMemNonce.value())
+    auto const newMaxNonce = uNonce + 1;
+    auto const written = co_await storage2::writeOneIf(m_maxNonces, sender, newMaxNonce,
+        [&](u256 const& existing) { return newMaxNonce >= existing; });
+    if (written && c_fileLogLevel == TRACE) [[unlikely]]
     {
-        if (c_fileLogLevel == TRACE) [[unlikely]]
-        {
-            TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: update max nonce")
-                              << LOG_KV("sender", toHex(sender))
-                              << LOG_KV("originNonce", maxMemNonce.value_or(0))
-                              << LOG_KV("newNonce", uNonce);
-        }
-        co_await storage2::writeOne(m_maxNonces, sender, uNonce + 1);
+        TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: update max nonce")
+                          << LOG_KV("sender", toHex(sender)) << LOG_KV("newNonce", uNonce);
     }
     co_return true;
 }

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
@@ -29,15 +29,24 @@ namespace bcos::txpool
 {
 constexpr static uint16_t DefaultBucketSize = 256;
 struct PairHash
-
 {
-    template <std::convertible_to<std::string_view> StringView>
-    std::size_t operator()(const std::pair<StringView, StringView>& pair) const
+    // Hash both pair.first (sender) and pair.second (nonce) so that different nonces from the
+    // same sender land in different buckets and can be independently looked up (FIB-52).
+    // Uses std::string_view for consistent hashing regardless of the concrete string type.
+    template <std::convertible_to<std::string_view> First,
+        std::convertible_to<std::string_view> Second>
+    std::size_t operator()(const std::pair<First, Second>& pair) const
     {
-        return std::hash<StringView>()(pair.first);
+        std::size_t seed = 0;
+        boost::hash_combine(seed, std::string_view{pair.first});
+        boost::hash_combine(seed, std::string_view{pair.second});
+        return seed;
     }
-    template <std::convertible_to<std::string_view> Lhs, std::convertible_to<std::string_view> Rhs>
-    bool operator()(const std::pair<Lhs, Lhs>& lhs, const std::pair<Rhs, Rhs>& rhs) const
+    template <std::convertible_to<std::string_view> LFirst,
+        std::convertible_to<std::string_view> LSecond, std::convertible_to<std::string_view> RFirst,
+        std::convertible_to<std::string_view> RSecond>
+    bool operator()(
+        const std::pair<LFirst, LSecond>& lhs, const std::pair<RFirst, RSecond>& rhs) const
     {
         return std::string_view{lhs.first} == std::string_view{rhs.first} &&
                std::string_view{lhs.second} == std::string_view{rhs.second};
@@ -51,7 +60,7 @@ struct StateNonceHash
         return std::hash<std::string_view>{}(std::string_view{sender});
     }
     template <std::convertible_to<std::string_view> Lhs, std::convertible_to<std::string_view> Rhs>
-    std::size_t operator()(const Lhs& lhs, const Rhs& rhs) const
+    bool operator()(const Lhs& lhs, const Rhs& rhs) const
     {
         return std::string_view{lhs} == std::string_view{rhs};
     }

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
@@ -52,6 +52,24 @@ struct PairHash
                std::string_view{lhs.second} == std::string_view{rhs.second};
     }
 };
+struct NonceKeyHash
+{
+    using is_transparent = void;
+    template <std::convertible_to<std::string_view> S>
+    std::size_t operator()(const std::pair<S, u256>& pair) const
+    {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, std::string_view{pair.first});
+        boost::hash_combine(seed, static_cast<uint64_t>(pair.second));
+        return seed;
+    }
+    template <std::convertible_to<std::string_view> Lhs, std::convertible_to<std::string_view> Rhs>
+    bool operator()(const std::pair<Lhs, u256>& lhs, const std::pair<Rhs, u256>& rhs) const
+    {
+        return std::string_view{lhs.first} == std::string_view{rhs.first} &&
+               lhs.second == rhs.second;
+    }
+};
 struct StateNonceHash
 {
     template <std::convertible_to<std::string_view> StringView>
@@ -140,8 +158,7 @@ public:
                     TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: rm mem nonce cache")
                                       << LOG_KV("sender", toHex(sender)) << LOG_KV("nonce", nonce);
                 }
-                co_await storage2::removeOne(
-                    m_memoryNonces, std::make_pair(sender, toQuantity(nonce)));
+                co_await storage2::removeOne(m_memoryNonces, std::make_pair(sender, nonce));
             }
         }
     }
@@ -168,7 +185,7 @@ public:
             {
                 ss << toHex(sender) << ":" << nonce << ", ";
             }
-            co_await storage2::removeOne(m_memoryNonces, std::make_pair(sender, nonce));
+            co_await storage2::removeOne(m_memoryNonces, std::make_pair(sender, u256(nonce)));
         }
         // Clear stale m_maxNonces for affected senders so getPendingNonce()
         // falls through to the ledger nonce instead of returning inflated values
@@ -203,9 +220,9 @@ private:
     // memory nonce cache the nonce of the sender in memory
     // every tx send by the sender, should bigger than the nonce in ledger state and unique in
     // memory
-    bcos::storage2::memory_storage::MemoryStorage<std::pair<std::string, std::string>,
-        std::monostate, storage2::memory_storage::LRU | storage2::memory_storage::CONCURRENT,
-        PairHash, PairHash>
+    bcos::storage2::memory_storage::MemoryStorage<std::pair<std::string, u256>, std::monostate,
+        storage2::memory_storage::LRU | storage2::memory_storage::CONCURRENT, NonceKeyHash,
+        NonceKeyHash>
         m_memoryNonces;
 
     // <sender address(bytes string) => nonce>

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
@@ -138,7 +138,8 @@ public:
                         << LOG_DESC("Web3Nonce: update ledger nonce cache")
                         << LOG_KV("sender", toHex(sender)) << LOG_KV("nonce", maxNonce);
                 }
-                co_await storage2::writeOne(m_ledgerStateNonces, sender, maxNonce);
+                co_await storage2::writeOneIf(m_ledgerStateNonces, sender, maxNonce,
+                    [&](u256 const& existing) { return maxNonce > existing; });
                 if (auto maxMemNonce = co_await storage2::readOne(m_maxNonces, sender);
                     maxMemNonce.has_value() && maxNonce >= maxMemNonce.value())
                 {

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
@@ -183,7 +183,7 @@ public:
      * @param nonce transaction nonce, number string
      * @return coroutine void
      */
-    virtual task::Task<void> insertMemoryNonce(std::string sender, std::string nonce);
+    virtual task::Task<bool> insertMemoryNonce(std::string sender, std::string nonce);
 
     virtual task::Task<std::optional<u256>> getPendingNonce(std::string_view sender);
 

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -640,6 +640,48 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB60_UnsealWithWrongBatchIdPreservesResealed)
+{
+    // FIB-60: When unsealing, the code moved txs to unsealTransactions regardless of whether
+    // they had been re-sealed by a newer batch. The fix adds a re-seal guard: if a tx is sealed
+    // and its batchId/batchHash doesn't match the unseal request, it is left sealed.
+    auto tx0 = makeTx("fib60_n0", false);
+    auto tx1 = makeTx("fib60_n1", false);
+    auto tx2 = makeTx("fib60_n2", false);
+    storage.insert(tx0);
+    storage.insert(tx1);
+    storage.insert(tx2);
+    BOOST_CHECK_EQUAL(storage.size(), 3);
+
+    // Seal all 3 txs with batch 1
+    HashType batchHash1 = HashType::generateRandomFixedBytes();
+    HashList batch1All{tx0->hash(), tx1->hash(), tx2->hash()};
+    BOOST_CHECK(storage.batchMarkTxs(batch1All, 1, batchHash1, true));
+    BOOST_CHECK(tx0->sealed());
+    BOOST_CHECK(tx1->sealed());
+    BOOST_CHECK(tx2->sealed());
+
+    // Re-seal tx0 and tx1 with batch 2 (simulates a competing proposer)
+    HashType batchHash2 = HashType::generateRandomFixedBytes();
+    HashList batch2Partial{tx0->hash(), tx1->hash()};
+    BOOST_CHECK(storage.batchMarkTxs(batch2Partial, 2, batchHash2, true));
+    BOOST_CHECK_EQUAL(tx0->batchId(), 2);
+    BOOST_CHECK_EQUAL(tx1->batchId(), 2);
+
+    // Now unseal with the old batch 1 — tx0 and tx1 must be protected by the re-seal guard
+    BOOST_CHECK(storage.batchMarkTxs(batch1All, 1, batchHash1, false));
+    // tx0, tx1 were re-sealed to batch 2: must remain sealed
+    BOOST_CHECK(tx0->sealed());
+    BOOST_CHECK(tx1->sealed());
+    // tx2 belonged to batch 1 and was not re-sealed: must be unsealed
+    BOOST_CHECK(!tx2->sealed());
+    // All 3 txs must still be present in the pool
+    BOOST_CHECK_EQUAL(storage.size(), 3);
+    BOOST_CHECK(storage.exists(tx0->hash()));
+    BOOST_CHECK(storage.exists(tx1->hash()));
+    BOOST_CHECK(storage.exists(tx2->hash()));
+}
+
 BOOST_AUTO_TEST_CASE(FIB48_AlreadyInTxPoolAndAcceptReturnsNone)
 {
     // FIB-48: When a transaction without a callback is re-submitted with a callback,

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -67,7 +67,7 @@ struct MemoryStorageFixture
                          void(tbb::concurrent_unordered_set<bcos::protocol::NonceType,
                              std::hash<bcos::protocol::NonceType>> const&)))
             .AlwaysDo([](auto const&) {});
-        fakeit::When(Method(mockNonceChecker, insert)).AlwaysDo([](auto const&) {});
+        fakeit::When(Method(mockNonceChecker, insert)).AlwaysDo([](auto const&) { return true; });
         fakeit::When(Method(mockNonceChecker, remove)).AlwaysDo([](auto const&) {});
     }
 
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
 
     fakeit::Mock<bcos::txpool::Web3NonceChecker> mockWeb3NonceChecker;
     fakeit::When(Method(mockWeb3NonceChecker, insertMemoryNonce))
-        .AlwaysDo([](auto, auto) -> task::Task<void> { co_return; });
+        .AlwaysDo([](auto, auto) -> task::Task<bool> { co_return true; });
 
     std::shared_ptr<bcos::txpool::Web3NonceChecker> web3NonceChecker(
         &mockWeb3NonceChecker.get(), [](bcos::txpool::Web3NonceChecker*) {});
@@ -638,6 +638,40 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
         auto result = storageNoSig.verifyAndSubmitTransaction(tx10, nullptr, false, false);
         // Result depends on other validation steps
     }
+}
+
+BOOST_AUTO_TEST_CASE(FIB51_TxPoolNonceCheckerInsertReturnsBool)
+{
+    // FIB-51: TxPoolNonceChecker::insert() now returns bool (true = newly inserted,
+    // false = already existed). This makes the check-and-reserve atomic per bucket,
+    // eliminating the TOCTOU window between separate checkNonce() + insert() calls.
+
+    TxPoolNonceChecker checker;
+
+    // First insert: nonce is new -> must return true
+    const std::string nonce1 = "fib51_nonce_unique";
+    BOOST_CHECK(checker.insert(nonce1) == true);
+
+    // Second insert of the same nonce: already exists -> must return false
+    BOOST_CHECK(checker.insert(nonce1) == false);
+
+    // Different nonce: returns true again
+    const std::string nonce2 = "fib51_nonce_other";
+    BOOST_CHECK(checker.insert(nonce2) == true);
+
+    // Concurrent test: 50 threads all insert the same nonce; exactly one must succeed
+    const std::string raceNonce = "fib51_race_nonce";
+    std::atomic<int> successCount{0};
+    tbb::parallel_for(tbb::blocked_range<int>(0, 50), [&](const tbb::blocked_range<int>& range) {
+        for (int i = range.begin(); i < range.end(); ++i)
+        {
+            if (checker.insert(raceNonce))
+            {
+                successCount.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+    BOOST_CHECK_EQUAL(successCount.load(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(FIB55_PoolLimitEnforced)

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -943,5 +943,63 @@ BOOST_AUTO_TEST_CASE(FIB65_SealAtIndex0UpdatesKnownHash)
     // Total: tx1 (sealed) + tx2 (now sealed after batchSealTransactions) = 2
     BOOST_CHECK_EQUAL(storage.size(), 2U);
 }
+BOOST_AUTO_TEST_CASE(FIB54_ConcurrentBatchMarkTxs)
+{
+    // FIB-54: batchMarkTxs used ReadAccessor inside the traverse callback but then
+    // called bucket.remove() and batchInsert() which need write access, causing a data
+    // race under concurrent sealing. The fix promotes to WriteAccessor for all mutations.
+    // This test inserts 50 txs and concurrently seals two non-overlapping batches to
+    // exercise the concurrent-write path.
+
+    constexpr int kTotal = 50;
+    constexpr int kBatch1End = 25;  // batch 1: indices 0..24, batch 2: indices 25..49
+
+    std::vector<bcostars::protocol::TransactionImpl::Ptr> txs;
+    txs.reserve(kTotal);
+    for (int i = 0; i < kTotal; ++i)
+    {
+        auto tx = makeTx("fib54_n" + std::to_string(i), false);
+        storage.insert(tx);
+        txs.push_back(tx);
+    }
+    BOOST_CHECK_EQUAL(storage.size(), static_cast<std::size_t>(kTotal));
+
+    HashType bh1 = HashType::generateRandomFixedBytes();
+    HashType bh2 = HashType::generateRandomFixedBytes();
+
+    HashList batch1;
+    HashList batch2;
+    for (int i = 0; i < kBatch1End; ++i)
+    {
+        batch1.push_back(txs[i]->hash());
+    }
+    for (int i = kBatch1End; i < kTotal; ++i)
+    {
+        batch2.push_back(txs[i]->hash());
+    }
+
+    // Seal both batches concurrently — must not crash or corrupt state (FIB-54)
+    tbb::parallel_invoke([&] { storage.batchMarkTxs(batch1, /*batchId=*/10, bh1, /*seal=*/true); },
+        [&] { storage.batchMarkTxs(batch2, /*batchId=*/11, bh2, /*seal=*/true); });
+
+    // All 50 txs must now be sealed
+    for (auto& tx : txs)
+    {
+        BOOST_CHECK(tx->sealed());
+    }
+    BOOST_CHECK_EQUAL(storage.size(), static_cast<std::size_t>(kTotal));
+
+    // Unseal both batches concurrently
+    tbb::parallel_invoke([&] { storage.batchMarkTxs(batch1, /*batchId=*/10, bh1, /*seal=*/false); },
+        [&] { storage.batchMarkTxs(batch2, /*batchId=*/11, bh2, /*seal=*/false); });
+
+    // All 50 txs must now be unsealed and still present
+    for (auto& tx : txs)
+    {
+        BOOST_CHECK(!tx->sealed());
+        BOOST_CHECK(storage.exists(tx->hash()));
+    }
+    BOOST_CHECK_EQUAL(storage.size(), static_cast<std::size_t>(kTotal));
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -26,9 +26,11 @@
 #include "bcos-utilities/DataConvertUtility.h"
 
 #include <sw/redis++/cxx_utils.h>
+#include <tbb/parallel_for.h>
 
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
+#include <atomic>
 #include <fakeit.hpp>
 
 using namespace bcos;
@@ -883,6 +885,63 @@ BOOST_AUTO_TEST_CASE(FIB50_NonceNotInsertedOnValidationFailure)
     BOOST_CHECK_EQUAL(r2, TransactionStatus::None);
     BOOST_CHECK(realNC->exists(goodNonce));
     BOOST_CHECK_EQUAL(stor.size(), 1U);
+}
+
+BOOST_AUTO_TEST_CASE(FIB65_SealAtIndex0UpdatesKnownHash)
+{
+    // FIB-65: batchMarkTxs must update m_knownLatestSealedTxHash even when the sealed
+    // transaction is at index 0 of the hash list. The old code used `> 0` which skipped
+    // index 0, leaving m_knownLatestSealedTxHash stale and causing batchSealTransactions
+    // to start from the wrong position on subsequent calls.
+
+    // Provide a real BlockFactory so batchSealTransactions can create TransactionMetaData
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto blockHeaderFactory =
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite);
+    auto txFactory = std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    auto receiptFactory =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite);
+    auto blockFactory = std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+        cryptoSuite, blockHeaderFactory, txFactory, receiptFactory);
+    config->setBlockFactory(blockFactory);
+
+    // Step 1: Insert tx1 (unsealed) and seal it via batchMarkTxs at index 0
+    auto tx1 = makeTx("fib65_nonce1", false);
+    tx1->setImportTime(static_cast<int64_t>(utcTime()));
+    storage.insert(tx1);
+    HashType batchHash = HashType::generateRandomFixedBytes();
+    HashList toSeal{tx1->hash()};  // tx1 is at index 0 — this is the bug trigger
+    bool ok = storage.batchMarkTxs(toSeal, /*batchId*/ 1, batchHash, /*sealFlag*/ true);
+    BOOST_CHECK(ok);
+    BOOST_CHECK(tx1->sealed());
+
+    // Step 2: Insert tx2 (unsealed) — should be found by the next batchSealTransactions
+    auto tx2 = makeTx("fib65_nonce2", false);
+    tx2->setImportTime(static_cast<int64_t>(utcTime()));
+    storage.insert(tx2);
+    BOOST_CHECK(!tx2->sealed());
+
+    // Step 3: batchSealTransactions must find tx2 regardless of m_knownLatestSealedTxHash
+    std::vector<protocol::TransactionMetaData::Ptr> txsList;
+    std::vector<protocol::TransactionMetaData::Ptr> sysTxsList;
+    bool result = storage.batchSealTransactions(txsList, sysTxsList, /*limit*/ 100);
+    BOOST_CHECK(result);
+
+    // tx2 must be in the output (the fix ensures rangeByKey starts from the correct position)
+    bool foundTx2 = false;
+    for (auto& meta : txsList)
+    {
+        if (meta->hash() == tx2->hash())
+        {
+            foundTx2 = true;
+            break;
+        }
+    }
+    BOOST_CHECK(foundTx2);
+    // Total: tx1 (sealed) + tx2 (now sealed after batchSealTransactions) = 2
+    BOOST_CHECK_EQUAL(storage.size(), 2U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -640,6 +640,35 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB48_AlreadyInTxPoolAndAcceptReturnsNone)
+{
+    // FIB-48: When a transaction without a callback is re-submitted with a callback,
+    // txpoolStorageCheck() returns AlreadyInTxPoolAndAccept and sets the callback.
+    // The old code continued through the lambda chain into insert(), causing a
+    // use-after-free and potential double-resume of the coroutine handle.
+    // The fix returns TransactionStatus::None immediately after registering the callback.
+
+    auto tx1 = makeTx("fib48_n1", false);
+    storage.insert(tx1);  // Insert without callback
+    BOOST_CHECK_EQUAL(storage.size(), 1U);
+
+    // Re-submit with a callback: tx exists, no prior callback → AlreadyInTxPoolAndAccept
+    // Fix: returns None immediately (callback accepted) without re-entering insert()
+    bool callbackCalled = false;
+    auto result = storage.verifyAndSubmitTransaction(
+        tx1,
+        [&callbackCalled](
+            Error::Ptr, protocol::TransactionSubmitResult::Ptr) { callbackCalled = true; },
+        false, false);
+    BOOST_CHECK(result == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(storage.size(), 1U);  // No duplicate insert
+
+    // Re-submit again: tx now has a callback → AlreadyInTxPool (rejected outright)
+    auto result2 = storage.verifyAndSubmitTransaction(tx1, nullptr, false, false);
+    BOOST_CHECK(result2 == TransactionStatus::AlreadyInTxPool);
+    BOOST_CHECK_EQUAL(storage.size(), 1U);
+}
+
 BOOST_AUTO_TEST_CASE(FIB50_NonceNotInsertedOnValidationFailure)
 {
     // FIB-50: nonce must only be inserted AFTER all validation steps pass.

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -8,8 +8,13 @@
 #include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
 #include "bcos-framework/ledger/LedgerInterface.h"
 #include "bcos-framework/txpool/Constant.h"
+#include "bcos-protocol/TransactionSubmitResultFactoryImpl.h"
 #include "bcos-protocol/TransactionSubmitResultImpl.h"
+#include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
 #include "bcos-task/Wait.h"
 #include "bcos-txpool/txpool/interfaces/NonceCheckerInterface.h"
 #include "bcos-txpool/txpool/interfaces/TxValidatorInterface.h"
@@ -38,8 +43,10 @@ struct MemoryStorageFixture
         txPoolNonceChecker(&mockNonceChecker.get(), [](bcos::txpool::NonceCheckerInterface*) {}),
         ledgerNonceChecker(&mockLedgerNonceChecker.get(), [](bcos::txpool::LedgerNonceChecker*) {}),
         ledger(&mockLedger.get(), [](bcos::ledger::LedgerInterface*) {}),
-        config(std::make_shared<TxPoolConfig>(txValidator, nullptr, nullptr, nullptr,
-            txPoolNonceChecker, /*blockLimit*/ 0, /*poolLimit*/ 1024, /*checkSig*/ false)),
+        config(std::make_shared<TxPoolConfig>(txValidator,
+            std::make_shared<bcos::protocol::TransactionSubmitResultFactoryImpl>(), nullptr,
+            nullptr, txPoolNonceChecker, /*blockLimit*/ 0, /*poolLimit*/ 1024,
+            /*checkSig*/ false)),
         storage(config)
     {
         fakeit::When(Method(mockValidator, checkTransaction))
@@ -638,6 +645,54 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
         auto result = storageNoSig.verifyAndSubmitTransaction(tx10, nullptr, false, false);
         // Result depends on other validation steps
     }
+}
+
+BOOST_AUTO_TEST_CASE(FIB61_NegativeImportTimeTreatedAsExpired)
+{
+    // FIB-61: A tx with negative importTime caused unsigned overflow when computing
+    // importTime + m_txsExpirationTime, potentially treating an expired tx as valid.
+    // The fix adds an explicit `importTime < 0` guard in batchSealTransactions.
+
+    // Set up a real BlockFactory required by batchSealTransactions
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto blockHeaderFactory =
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite);
+    auto txFactory = std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    auto receiptFactory =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite);
+    auto blockFactory = std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+        cryptoSuite, blockHeaderFactory, txFactory, receiptFactory);
+    config->setBlockFactory(blockFactory);
+
+    // tx1: negative import time — must be treated as expired
+    auto tx1 = makeTx("fib61_expired", false);
+    tx1->setImportTime(-1);
+    storage.insert(tx1);
+
+    // tx2: current time — must be included in sealed output
+    auto tx2 = makeTx("fib61_valid", false);
+    tx2->setImportTime(static_cast<int64_t>(utcTime()));
+    storage.insert(tx2);
+
+    std::vector<protocol::TransactionMetaData::Ptr> txsList;
+    std::vector<protocol::TransactionMetaData::Ptr> sysTxsList;
+    storage.batchSealTransactions(txsList, sysTxsList, 100);
+
+    bool foundTx1 = false;
+    bool foundTx2 = false;
+    for (auto& meta : txsList)
+    {
+        if (meta->hash() == tx1->hash())
+            foundTx1 = true;
+        if (meta->hash() == tx2->hash())
+            foundTx2 = true;
+    }
+    // tx1 must be excluded (treated as expired due to negative importTime)
+    BOOST_CHECK(!foundTx1);
+    // tx2 must be included
+    BOOST_CHECK(foundTx2);
 }
 
 BOOST_AUTO_TEST_CASE(FIB51_TxPoolNonceCheckerInsertReturnsBool)

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -640,4 +640,63 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB50_NonceNotInsertedOnValidationFailure)
+{
+    // FIB-50: nonce must only be inserted AFTER all validation steps pass.
+    // Old code called txPoolNonceChecker->insert() inside TxValidator::verify() — before
+    // validateTransaction(). If validateTransaction later failed (e.g. OverFlowValue), the
+    // nonce was already stuck in the pool, preventing valid re-submission.
+    // Fix: nonce insertion is deferred to verifyAndSubmitTransaction(), after all steps pass.
+
+    // Use a real TxPoolNonceChecker so we can query exists()
+    auto realNC = std::make_shared<TxPoolNonceChecker>();
+    std::shared_ptr<NonceCheckerInterface> nc = realNC;
+
+    // Fresh validator mock with all required methods set up
+    fakeit::Mock<bcos::txpool::TxValidatorInterface> localValidator;
+    fakeit::Mock<bcos::txpool::LedgerNonceChecker> localLNC;
+    auto web3Checker = std::make_shared<bcos::txpool::Web3NonceChecker>(nullptr);
+    fakeit::When(Method(localValidator, web3NonceChecker)).AlwaysReturn(web3Checker);
+    auto lnc = std::shared_ptr<bcos::txpool::LedgerNonceChecker>(&localLNC.get(), [](auto*) {});
+    fakeit::When(Method(localValidator, ledgerNonceChecker)).AlwaysReturn(lnc);
+    fakeit::When(Method(localLNC, batchInsert)).AlwaysDo([](auto, auto const&) {});
+
+    // verify() always passes — bypasses real signature verification for test simplicity
+    fakeit::When(Method(localValidator, verify)).AlwaysReturn(TransactionStatus::None);
+
+    // validateTransaction(): reject the bad nonce, accept all others
+    const std::string badNonce = "fib50_bad_nonce";
+    fakeit::When(Method(localValidator, validateTransaction))
+        .AlwaysDo([badNonce](const bcos::protocol::Transaction& tx) -> TransactionStatus {
+            return std::string(tx.nonce()) == badNonce ? TransactionStatus::OverFlowValue :
+                                                         TransactionStatus::None;
+        });
+
+    // validateChainId() always passes
+    fakeit::When(Method(localValidator, validateChainId))
+        .AlwaysDo([](const auto&, auto) -> task::Task<TransactionStatus> {
+            co_return TransactionStatus::None;
+        });
+
+    std::shared_ptr<TxValidatorInterface> v(&localValidator.get(), [](auto*) {});
+    auto cfg = std::make_shared<TxPoolConfig>(
+        v, nullptr, nullptr, nullptr, nc, 1000, 1024, /*checkSig=*/true);
+    MemoryStorage stor(cfg);
+
+    // 1. Bad tx: validateTransaction returns OverFlowValue → chain stops → nonce NOT inserted
+    auto badTx = makeTx(badNonce, false);
+    auto r1 = stor.verifyAndSubmitTransaction(badTx, nullptr, false, false);
+    BOOST_CHECK_EQUAL(r1, TransactionStatus::OverFlowValue);
+    // FIB-50 fix: nonce was not inserted because validation failed before the insertion point
+    BOOST_CHECK(!realNC->exists(badNonce));
+
+    // 2. Good tx: all steps pass → nonce IS inserted and tx enters pool
+    const std::string goodNonce = "fib50_good_nonce";
+    auto goodTx = makeTx(goodNonce, false);
+    auto r2 = stor.verifyAndSubmitTransaction(goodTx, nullptr, false, false);
+    BOOST_CHECK_EQUAL(r2, TransactionStatus::None);
+    BOOST_CHECK(realNC->exists(goodNonce));
+    BOOST_CHECK_EQUAL(stor.size(), 1U);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -640,6 +640,32 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB55_PoolLimitEnforced)
+{
+    // FIB-55: Pool limit was bypassed because the check happened after expensive validation.
+    // The fix moves the pool limit check (Step 1.5) before signature verification and nonce
+    // checks so that TxPoolIsFull is returned early.
+    constexpr size_t kLimit = 3;
+    auto limitedConfig = std::make_shared<TxPoolConfig>(txValidator, nullptr, nullptr, nullptr,
+        txPoolNonceChecker, /*blockLimit*/ 0, /*poolLimit*/ kLimit, /*checkSig*/ false);
+    MemoryStorage limitedStorage(limitedConfig);
+
+    // Insert kLimit txs directly (bypasses validator, fills the pool)
+    for (size_t i = 0; i < kLimit; ++i)
+    {
+        auto tx = makeTx("fib55_n" + std::to_string(i), false);
+        BOOST_CHECK_EQUAL(limitedStorage.insert(tx), TransactionStatus::None);
+    }
+    BOOST_CHECK_EQUAL(limitedStorage.size(), kLimit);
+
+    // Submitting a new tx with checkPoolLimit=true must be rejected before reaching validation
+    auto tx4 = makeTx("fib55_n3", false);
+    auto result =
+        limitedStorage.verifyAndSubmitTransaction(tx4, nullptr, /*checkPoolLimit*/ true, false);
+    BOOST_CHECK_EQUAL(result, TransactionStatus::TxPoolIsFull);
+    BOOST_CHECK_EQUAL(limitedStorage.size(), kLimit);
+}
+
 BOOST_AUTO_TEST_CASE(FIB60_UnsealWithWrongBatchIdPreservesResealed)
 {
     // FIB-60: When unsealing, the code moved txs to unsealTransactions regardless of whether

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -307,5 +307,37 @@ BOOST_AUTO_TEST_CASE(FIB57_RejectOversizedNonceString)
     BOOST_CHECK_EQUAL(statusLong, TransactionStatus::NonceCheckFail);
 }
 
+BOOST_AUTO_TEST_CASE(FIB58_NonceNormalizationDetectsDuplicates)
+{
+    // FIB-58: insertMemoryNonce and checkWeb3Nonce used different nonce representations
+    // (raw string vs u256), so "0x1", "0x01", and "1" were treated as distinct nonces.
+    // The fix normalizes via toQuantity(u256(nonce)) in both paths so all forms map to the
+    // same canonical key.
+    const std::string sender1 = Address::generateRandomFixedBytes().toRawString();
+
+    // Insert nonce "0x1" (hex notation)
+    task::syncWait(checker.insertMemoryNonce(sender1, "0x1"));
+
+    // "0x1", "0x01", and "1" should all be detected as duplicates
+    BOOST_CHECK_EQUAL(
+        task::syncWait(checker.checkWeb3Nonce(sender1, "0x1")), TransactionStatus::NonceCheckFail);
+    BOOST_CHECK_EQUAL(
+        task::syncWait(checker.checkWeb3Nonce(sender1, "0x01")), TransactionStatus::NonceCheckFail);
+    BOOST_CHECK_EQUAL(
+        task::syncWait(checker.checkWeb3Nonce(sender1, "1")), TransactionStatus::NonceCheckFail);
+
+    // Different nonce should still pass
+    BOOST_CHECK_EQUAL(
+        task::syncWait(checker.checkWeb3Nonce(sender1, "0x2")), TransactionStatus::None);
+
+    // Decimal 16 == hex 0x10: both should collide after inserting "0x10"
+    const std::string sender2 = Address::generateRandomFixedBytes().toRawString();
+    task::syncWait(checker.insertMemoryNonce(sender2, "0x10"));
+    BOOST_CHECK_EQUAL(
+        task::syncWait(checker.checkWeb3Nonce(sender2, "16")), TransactionStatus::NonceCheckFail);
+    BOOST_CHECK_EQUAL(
+        task::syncWait(checker.checkWeb3Nonce(sender2, "0x10")), TransactionStatus::NonceCheckFail);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -339,5 +339,32 @@ BOOST_AUTO_TEST_CASE(FIB58_NonceNormalizationDetectsDuplicates)
         task::syncWait(checker.checkWeb3Nonce(sender2, "0x10")), TransactionStatus::NonceCheckFail);
 }
 
+BOOST_AUTO_TEST_CASE(FIB59_CacheHitSkipsLedgerQuery)
+{
+    // FIB-59: After checking m_ledgerStateNonces, the code unconditionally queried storage
+    // and could overwrite a higher cached value with a stale lower one.
+    // The fix short-circuits on cache hit, skipping storage entirely and keeping the
+    // monotonically increasing cached value intact.
+    const std::string sender = Address::generateRandomFixedBytes().toRawString();
+    const std::string senderHex = toHex(sender);
+
+    // Prime the ledger state nonce cache with nonce=10
+    checker.insert(sender, 10);
+
+    // Ledger storage has a lower stale nonce=0 (simulates a block that hasn't propagated yet)
+    ledger::StorageState storageState{.nonce = "0", .balance = "1"};
+    m_ledger->setStorageState(senderHex, std::move(storageState));
+
+    // nonce=11 (0xb) should pass: 11 >= cached 10 and within limit
+    auto status = task::syncWait(checker.checkWeb3Nonce(sender, "0xb"));
+    BOOST_CHECK_EQUAL(status, TransactionStatus::None);
+
+    // The cache must NOT have been overwritten by the stale storage nonce=0.
+    // getPendingNonce reads m_ledgerStateNonces; with the fix it must return 10, not 0.
+    auto pending = task::syncWait(checker.getPendingNonce(senderHex));
+    BOOST_CHECK(pending.has_value());
+    BOOST_CHECK_EQUAL(pending.value(), 10);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -217,5 +217,30 @@ BOOST_AUTO_TEST_CASE(testStorageLayerNonce)
     BOOST_CHECK_EQUAL(errorCount, totalSize);
 }
 
+BOOST_AUTO_TEST_CASE(FIB57_RejectOversizedNonceString)
+{
+    // FIB-57: Oversized nonce strings must be rejected at the earliest validation point —
+    // checkWeb3Nonce() — before any u256 conversion, to prevent LRU capacity accounting bypass.
+    constexpr size_t MAX_LEN = 78;  // max decimal digits of u256
+
+    // A nonce exactly at the limit (78 chars) should pass checkWeb3Nonce
+    const std::string sender78 = Address::generateRandomFixedBytes().toRawString();
+    const std::string nonce78(MAX_LEN, '1');
+    auto status78 = task::syncWait(checker.checkWeb3Nonce(sender78, nonce78));
+    BOOST_CHECK_EQUAL(status78, TransactionStatus::None);
+
+    // A nonce one byte over the limit (79 chars) must be rejected by checkWeb3Nonce
+    const std::string sender79 = Address::generateRandomFixedBytes().toRawString();
+    const std::string nonce79(MAX_LEN + 1, '1');
+    auto status79 = task::syncWait(checker.checkWeb3Nonce(sender79, nonce79));
+    BOOST_CHECK_EQUAL(status79, TransactionStatus::NonceCheckFail);
+
+    // A very long nonce (1000 chars) must also be rejected by checkWeb3Nonce
+    const std::string senderLong = Address::generateRandomFixedBytes().toRawString();
+    const std::string nonce1000(1000, '9');
+    auto statusLong = task::syncWait(checker.checkWeb3Nonce(senderLong, nonce1000));
+    BOOST_CHECK_EQUAL(statusLong, TransactionStatus::NonceCheckFail);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -23,13 +23,16 @@
 #include <bcos-txpool/txpool/validator/Web3NonceChecker.h>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/test/unit_test.hpp>
+#include <atomic>
 #include <memory>
 #include <range/v3/all.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 #include <ranges>
 #include <set>
+#include <thread>
 #include <unordered_map>
+#include <vector>
 
 using namespace bcos;
 using namespace bcos::txpool;
@@ -77,7 +80,7 @@ BOOST_AUTO_TEST_CASE(testNormalFlow)
     {
         auto status = task::syncWait(checker.checkWeb3Nonce(sender, nonce));
         BOOST_CHECK_EQUAL(status, TransactionStatus::None);
-        task::syncWait(checker.insertMemoryNonce(sender, nonce));
+        BOOST_CHECK(task::syncWait(checker.insertMemoryNonce(sender, nonce)));
     }
     // commit
     std::unordered_map<std::string, std::set<u256>> commitMap = {};
@@ -105,7 +108,8 @@ BOOST_AUTO_TEST_CASE(testNormalFlow)
     // new pending
     for (auto&& sender : senders)
     {
-        task::syncWait(checker.insertMemoryNonce(sender, (*commitMap[sender].rbegin() + 2).str()));
+        BOOST_CHECK(task::syncWait(
+            checker.insertMemoryNonce(sender, (*commitMap[sender].rbegin() + 2).str())));
         auto nonce = task::syncWait(checker.getPendingNonce(toHex(sender)));
         BOOST_CHECK(nonce.has_value());
         BOOST_CHECK_EQUAL(nonce.value(), *commitMap[sender].rbegin() + 2 + 1);
@@ -117,7 +121,7 @@ BOOST_AUTO_TEST_CASE(testNormalFlow)
         auto nonce = task::syncWait(checker.getPendingNonce(toHex(newSender)));
         BOOST_CHECK(!nonce.has_value());
 
-        task::syncWait(checker.insertMemoryNonce(newSender, "1"));
+        BOOST_CHECK(task::syncWait(checker.insertMemoryNonce(newSender, "1")));
         nonce = task::syncWait(checker.getPendingNonce(toHex(newSender)));
         BOOST_CHECK(nonce.has_value());
         BOOST_CHECK_EQUAL(nonce.value(), 2);
@@ -140,7 +144,7 @@ BOOST_AUTO_TEST_CASE(testInvalidNonce)
         }
         else
         {
-            task::syncWait(checker.insertMemoryNonce(sender, nonce));
+            BOOST_CHECK(task::syncWait(checker.insertMemoryNonce(sender, nonce)));
         }
     }
     BOOST_CHECK_EQUAL(dupCount, dupSize);
@@ -215,6 +219,36 @@ BOOST_AUTO_TEST_CASE(testStorageLayerNonce)
         }
     }
     BOOST_CHECK_EQUAL(errorCount, totalSize);
+}
+
+BOOST_AUTO_TEST_CASE(testAtomicInsertMemoryNonce)
+{
+    // 50 concurrent threads all try to insert the same (sender, nonce) pair.
+    // Exactly one must succeed; the rest must return false.
+    constexpr int threadCount = 50;
+    auto sender = Address::generateRandomFixedBytes().toRawString();
+    std::string nonce = "42";
+
+    std::atomic<int> successCount{0};
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+
+    for (int i = 0; i < threadCount; ++i)
+    {
+        threads.emplace_back([&]() {
+            bool inserted = task::syncWait(checker.insertMemoryNonce(sender, nonce));
+            if (inserted)
+            {
+                successCount.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    BOOST_CHECK_EQUAL(successCount.load(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(FIB52_PairHashDistinguishesSecondElement)

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -217,6 +217,37 @@ BOOST_AUTO_TEST_CASE(testStorageLayerNonce)
     BOOST_CHECK_EQUAL(errorCount, totalSize);
 }
 
+BOOST_AUTO_TEST_CASE(FIB52_PairHashDistinguishesSecondElement)
+{
+    // FIB-52: The old PairHash only hashed pair.first (sender) and ignored pair.second
+    // (nonce), causing all (sender, *) pairs to collide in the same hash bucket. The fix
+    // combines hashes of both elements using a Fibonacci multiplier to spread nonces.
+
+    bcos::txpool::PairHash hasher;
+
+    const std::string senderA = "sender_alpha_addr_xyz";
+    const std::string senderB = "sender_beta_addr_abc";
+    const std::string nonce1 = "0x0001";
+    const std::string nonce2 = "0x0002";
+
+    // Same sender, different nonces must hash differently (old code: same hash = collision)
+    auto h1 = hasher(std::make_pair(senderA, nonce1));
+    auto h2 = hasher(std::make_pair(senderA, nonce2));
+    BOOST_CHECK_NE(h1, h2);
+
+    // Consistency: same inputs must produce the same hash
+    BOOST_CHECK_EQUAL(h1, hasher(std::make_pair(senderA, nonce1)));
+
+    // Different senders, same nonce must also hash differently
+    auto h3 = hasher(std::make_pair(senderB, nonce1));
+    BOOST_CHECK_NE(h1, h3);
+
+    // Equality predicate: (A,n1) == (A,n1) and (A,n1) != (A,n2)
+    BOOST_CHECK(hasher(std::make_pair(senderA, nonce1), std::make_pair(senderA, nonce1)));
+    BOOST_CHECK(!hasher(std::make_pair(senderA, nonce1), std::make_pair(senderA, nonce2)));
+    BOOST_CHECK(!hasher(std::make_pair(senderA, nonce1), std::make_pair(senderB, nonce1)));
+}
+
 BOOST_AUTO_TEST_CASE(FIB57_RejectOversizedNonceString)
 {
     // FIB-57: Oversized nonce strings must be rejected at the earliest validation point —

--- a/bcos-utilities/bcos-utilities/BucketMap.h
+++ b/bcos-utilities/bcos-utilities/BucketMap.h
@@ -27,6 +27,7 @@
 #include <oneapi/tbb/parallel_for.h>
 #include <oneapi/tbb/parallel_for_each.h>
 #include <oneapi/tbb/rw_mutex.h>
+#include <rapidhash.h>
 #include <concepts>
 #include <optional>
 #include <random>
@@ -49,21 +50,42 @@ class EmptyType
 {
 };
 
-struct StringHash
+struct RapidHasher
 {
     using is_transparent = void;
+
+    static uint64_t globalSeed()
+    {
+        static const uint64_t s = [] {
+            std::random_device rd;
+            uint64_t v = rd();
+            v ^= static_cast<uint64_t>(rd()) << 32U;
+            return v;
+        }();
+        return s;
+    }
 
     template <std::convertible_to<std::string_view> T>
     std::size_t operator()(const T& str) const
     {
-        return std::hash<std::decay_t<T>>{}(str);
+        auto sv = std::string_view{str};
+        return static_cast<std::size_t>(rapidhash_withSeed(sv.data(), sv.size(), globalSeed()));
+    }
+
+    template <typename T>
+        requires std::is_trivially_copyable_v<T> && (!std::convertible_to<T, std::string_view>)
+    std::size_t operator()(const T& val) const
+    {
+        return static_cast<std::size_t>(rapidhash_withSeed(&val, sizeof(val), globalSeed()));
     }
 };
 
+using StringHash = RapidHasher;
+
 template <class KeyType, class ValueType,
     class MapType = std::conditional_t<std::is_same_v<KeyType, std::string>,
-        std::unordered_map<std::string, ValueType, StringHash, std::equal_to<>>,
-        std::unordered_map<KeyType, ValueType>>>
+        std::unordered_map<std::string, ValueType, RapidHasher, std::equal_to<>>,
+        std::unordered_map<KeyType, ValueType, RapidHasher>>>
 class Bucket : public std::enable_shared_from_this<Bucket<KeyType, ValueType, MapType>>
 {
 public:
@@ -167,8 +189,11 @@ public:
     mutable SharedMutex m_mutex;
 };
 
-template <class KeyType, class ValueType, class BucketHasher = std::hash<KeyType>,
-    class BucketType = Bucket<KeyType, ValueType>>
+template <class KeyType, class ValueType, class BucketHasher = RapidHasher,
+    class BucketType = Bucket<KeyType, ValueType,
+        std::conditional_t<std::is_same_v<KeyType, std::string>,
+            std::unordered_map<std::string, ValueType, BucketHasher, std::equal_to<>>,
+            std::unordered_map<KeyType, ValueType, BucketHasher>>>>
 class BucketMap
 {
 private:
@@ -380,7 +405,7 @@ public:
     }
 };
 
-template <class KeyType, class BucketHasher = std::hash<KeyType>>
+template <class KeyType, class BucketHasher = RapidHasher>
 class BucketSet : public BucketMap<KeyType, EmptyType, BucketHasher>
 {
 public:

--- a/bcos-utilities/bcos-utilities/BucketMap.h
+++ b/bcos-utilities/bcos-utilities/BucketMap.h
@@ -106,11 +106,42 @@ public:
     private:
         std::conditional_t<write, typename MapType::iterator, typename MapType::const_iterator>
             m_iterator;
-        std::conditional_t<write, Bucket*, const Bucket*> m_bucket;
+        std::conditional_t<write, Bucket*, const Bucket*> m_bucket{};
         std::optional<Guard> m_guard;
 
     public:
         BaseAccessor() = default;
+
+        /// Upgrade the held lock from shared (reader) to exclusive (writer).
+        /// Returns true if the upgrade was atomic (no gap); false if the lock
+        /// was briefly released and re-acquired — in that case, the iterator
+        /// may be invalid and the caller should call revalidate().
+        bool upgradeToWriter()
+        {
+            if (m_guard)
+            {
+                return m_guard->upgrade_to_writer();
+            }
+            return false;
+        }
+
+        /// Re-find the element in the same bucket after a non-atomic lock upgrade.
+        /// Returns true if the element still exists, false otherwise.
+        bool revalidate(const KeyType& key)
+        {
+            if (!m_bucket)
+            {
+                return false;
+            }
+            auto it = m_bucket->m_values.find(key);
+            if (it != m_bucket->m_values.end())
+            {
+                m_iterator = it;
+                return true;
+            }
+            return false;
+        }
+
         void emplaceLock(SharedMutex& mutex)
         {
             if (!m_guard)

--- a/bcos-utilities/bcos-utilities/DataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/DataConvertUtility.h
@@ -489,4 +489,5 @@ std::string toQuantity(BigNumber auto number)
     auto bytes = toCompactBigEndian(number);
     return toQuantity(bytes);
 }
+
 }  // namespace bcos

--- a/bcos-utilities/test/unittests/libutilities/BucketMapTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/BucketMapTest.cpp
@@ -491,6 +491,43 @@ BOOST_AUTO_TEST_CASE(bucketSetBatchInsertReturn)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB64_StringHashRandomSeedConsistency)
+{
+    // FIB-64: The bucket hash function was deterministic (no seed), allowing an attacker
+    // to craft keys that all land in the same bucket (HashDoS). The fix mixes a per-process
+    // random seed (from std::random_device) into StringHash to prevent bucket flooding.
+    bcos::StringHash hasher;
+
+    // Seed must be non-zero (probability 1/2^64 of false failure)
+    BOOST_CHECK_NE(bcos::StringHash::globalSeed(), static_cast<std::size_t>(0));
+
+    // Intra-process consistency: same key must produce the same hash value
+    BOOST_CHECK_EQUAL(hasher("key_alpha"), hasher("key_alpha"));
+    BOOST_CHECK_EQUAL(hasher(std::string("key_beta")), hasher(std::string("key_beta")));
+
+    // Different keys must (almost certainly) produce different hashes
+    BOOST_CHECK_NE(hasher("key1"), hasher("key2"));
+    BOOST_CHECK_NE(hasher("key1"), hasher("key1 "));
+
+    // Functional correctness: BucketMap with StringHash must store and retrieve all items
+    using BKMap = bcos::BucketMap<std::string, int>;
+    using WriteAccessor = BKMap::WriteAccessor;
+    BKMap m(16);
+    for (int i = 0; i < 100; ++i)
+    {
+        WriteAccessor acc;
+        m.insert(acc, {std::to_string(i), i});
+    }
+    BOOST_CHECK_EQUAL(m.size(), 100);
+    for (int i = 0; i < 100; ++i)
+    {
+        BOOST_CHECK(m.contains(std::to_string(i)));
+        WriteAccessor acc;
+        BOOST_CHECK(m.find<WriteAccessor>(acc, std::to_string(i)));
+        BOOST_CHECK_EQUAL(acc.value(), i);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace test
 }  // namespace bcos

--- a/ports/rapidhash/portfile.cmake
+++ b/ports/rapidhash/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO Nicoshev/rapidhash
+  REF bc4b4baa48a15ff52ff4725e1ccdcda62815221c # tag rapidhash_v3
+  SHA512 470e6c3749ae4648aadd81ce0f1acf3d02595b73a804483eb7f5ab03144639618d6d30dc67eb5a132d99bde82c307ad2bf71570d27e15e577efa2f16489b3103
+  HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/rapidhash.h" DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rapidhash/vcpkg.json
+++ b/ports/rapidhash/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "rapidhash",
+  "version": "3",
+  "port-version": 1,
+  "description": "Very fast, high quality, platform independent hashing algorithm.",
+  "homepage": "https://github.com/Nicoshev/rapidhash",
+  "license": "BSD-2-Clause"
+}

--- a/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
@@ -44,7 +44,7 @@ private:
     }
 
     friend auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/,
-        ReadWriteSetStorage& storage, ::ranges::input_range auto keys)
+        ReadWriteSetStorage& storage, ::ranges::forward_range auto keys)
         -> task::Task<task::AwaitableReturnType<
             std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys)>>>
     {
@@ -56,10 +56,15 @@ private:
     }
 
     friend auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/,
-        ReadWriteSetStorage& storage, ::ranges::input_range auto keys, storage2::DIRECT_TYPE direct)
+        ReadWriteSetStorage& storage, ::ranges::forward_range auto keys,
+        storage2::DIRECT_TYPE direct)
         -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::ReadSome,
             std::add_lvalue_reference_t<Storage>, decltype(std::move(keys))>>>
     {
+        for (auto&& key : keys)
+        {
+            storage.putSet(false, key);
+        }
         co_return co_await storage2::readSome(storage.m_storage.get(), std::move(keys), direct);
     }
 
@@ -77,6 +82,7 @@ private:
         -> task::Task<task::AwaitableReturnType<
             std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key)>>>
     {
+        storage.putSet(false, key);
         co_return co_await storage2::readOne(storage.m_storage.get(), key, direct);
     }
 
@@ -85,43 +91,57 @@ private:
         -> task::Task<task::AwaitableReturnType<
             std::invoke_result_t<storage2::WriteOne, Storage&, decltype(key), decltype(value)>>>
     {
-        storage.putSet(true, key);
+        auto keyCopy = key;
         co_await storage2::writeOne(storage.m_storage.get(), std::move(key), std::move(value));
+        storage.putSet(true, keyCopy);
     }
 
     friend auto tag_invoke(storage2::tag_t<storage2::writeSome> /*unused*/,
-        ReadWriteSetStorage& storage, ::ranges::input_range auto keyValues)
+        ReadWriteSetStorage& storage, ::ranges::forward_range auto keyValues)
         -> task::Task<task::AwaitableReturnType<
             std::invoke_result_t<storage2::WriteSome, Storage&, decltype(keyValues)>>>
     {
+        std::vector<Key> trackedKeys;
         for (auto&& [key, _] : keyValues)
+        {
+            trackedKeys.push_back(key);
+        }
+        co_await storage2::writeSome(storage.m_storage.get(), std::move(keyValues));
+        for (auto&& key : trackedKeys)
         {
             storage.putSet(true, key);
         }
-        co_return co_await storage2::writeSome(storage.m_storage.get(), std::move(keyValues));
     }
 
     friend task::Task<void> tag_invoke(storage2::tag_t<storage2::removeOne> /*unused*/,
         ReadWriteSetStorage& storage, auto key, auto&&... args)
     {
-        storage.putSet(true, key);
+        auto keyCopy = key;
         co_await storage2::removeOne(
             storage.m_storage.get(), std::move(key), std::forward<decltype(args)>(args)...);
+        storage.putSet(true, keyCopy);
     }
 
     friend auto tag_invoke(storage2::tag_t<storage2::removeSome> /*unused*/,
-        ReadWriteSetStorage& storage, ::ranges::input_range auto keys, auto&&... args)
+        ReadWriteSetStorage& storage, ::ranges::forward_range auto keys, auto&&... args)
         -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::RemoveSome, Storage&,
             decltype(keys), decltype(args)...>>>
     {
+        std::vector<Key> trackedKeys;
         for (auto&& key : keys)
+        {
+            trackedKeys.push_back(key);
+        }
+        co_await storage2::removeSome(
+            storage.m_storage.get(), std::move(keys), std::forward<decltype(args)>(args)...);
+        for (auto&& key : trackedKeys)
         {
             storage.putSet(true, key);
         }
-        co_return co_await storage2::removeSome(
-            storage.m_storage.get(), std::move(keys), std::forward<decltype(args)>(args)...);
     }
 
+    // NOTE: range() does not track reads because it returns a lazy iterator whose
+    // keys are not known until consumption. This is a known limitation (FIB-100).
     friend auto tag_invoke(bcos::storage2::tag_t<storage2::range> /*unused*/,
         ReadWriteSetStorage& storage, auto&&... args)
         -> task::Task<storage2::ReturnType<

--- a/transaction-scheduler/tests/FIB100_FIB106_FIB109_ReadWriteSetTest.cpp
+++ b/transaction-scheduler/tests/FIB100_FIB106_FIB109_ReadWriteSetTest.cpp
@@ -1,0 +1,213 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB100_FIB106_FIB109_ReadWriteSetTest.cpp
+ */
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/Storage.h"
+#include <bcos-task/Wait.h>
+#include <bcos-transaction-scheduler/ReadWriteSetStorage.h>
+#include <boost/test/unit_test.hpp>
+#include <range/v3/view/single.hpp>
+
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::scheduler_v1;
+
+// Mock storage that supports DIRECT reads (readOne and readSome)
+struct DirectMockStorage
+{
+    using Key = int;
+    using Value = int;
+};
+
+// writeOne: no-op store for tracking tests
+task::Task<void> tag_invoke(storage2::tag_t<storage2::writeOne> /*unused*/,
+    DirectMockStorage& /*storage*/, auto /*key*/, auto /*value*/)
+{
+    co_return;
+}
+
+// readOne without DIRECT: should not be called in DIRECT tests
+task::Task<std::optional<int>> tag_invoke(
+    storage2::tag_t<storage2::readOne> /*unused*/, DirectMockStorage& /*storage*/, auto&& /*key*/)
+{
+    co_return std::nullopt;
+}
+
+// readOne with DIRECT: returns key * 10
+task::Task<std::optional<int>> tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/,
+    DirectMockStorage& /*storage*/, const auto& key, storage2::DIRECT_TYPE /*unused*/)
+{
+    co_return std::make_optional(key * 10);
+}
+
+// readSome without DIRECT
+task::Task<std::vector<std::optional<int>>> tag_invoke(
+    storage2::tag_t<storage2::readSome> /*unused*/, DirectMockStorage& /*storage*/,
+    ::ranges::forward_range auto keys)
+{
+    std::vector<std::optional<int>> result;
+    for (auto&& key : keys)
+    {
+        result.emplace_back(key);
+    }
+    co_return result;
+}
+
+// readSome with DIRECT: returns key * 10 for each key
+task::Task<std::vector<std::optional<int>>> tag_invoke(
+    storage2::tag_t<storage2::readSome> /*unused*/, DirectMockStorage& /*storage*/,
+    ::ranges::forward_range auto keys, storage2::DIRECT_TYPE /*unused*/)
+{
+    std::vector<std::optional<int>> result;
+    for (auto&& key : keys)
+    {
+        result.emplace_back(key * 10);
+    }
+    co_return result;
+}
+
+BOOST_AUTO_TEST_SUITE(FIB100_FIB106_FIB109_ReadWriteSetTest)
+
+// FIB-100: DIRECT readOne now tracks the key in the read set
+BOOST_AUTO_TEST_CASE(directReadOneTracksReadSet)
+{
+    task::syncWait([]() -> task::Task<void> {
+        DirectMockStorage mockStorage;
+        ReadWriteSetStorage<decltype(mockStorage)> rwStorage(mockStorage);
+
+        // Write key 42 via a second storage (to detect RAW)
+        DirectMockStorage writerBackend;
+        ReadWriteSetStorage<decltype(writerBackend)> writerStorage(writerBackend);
+        co_await storage2::writeOne(writerStorage, 42, 1);
+
+        // DIRECT readOne key 42 should now track it
+        auto value = co_await storage2::readOne(rwStorage, 42, storage2::DIRECT);
+        BOOST_CHECK(value);
+        BOOST_CHECK_EQUAL(*value, 420);
+
+        // The read of key 42 should create a RAW intersection with the writer
+        BOOST_CHECK(hasRAWIntersection(writerStorage, rwStorage));
+
+        co_return;
+    }());
+}
+
+// FIB-100: DIRECT readSome now tracks keys in the read set
+BOOST_AUTO_TEST_CASE(directReadSomeTracksReadSet)
+{
+    task::syncWait([]() -> task::Task<void> {
+        DirectMockStorage mockStorage;
+        ReadWriteSetStorage<decltype(mockStorage)> rwStorage(mockStorage);
+
+        // Write key 5 via a separate storage
+        DirectMockStorage writerBackend;
+        ReadWriteSetStorage<decltype(writerBackend)> writerStorage(writerBackend);
+        co_await storage2::writeOne(writerStorage, 5, 1);
+
+        // DIRECT readSome keys {3, 5, 7}
+        std::vector<int> keys = {3, 5, 7};
+        auto values = co_await storage2::readSome(rwStorage, keys, storage2::DIRECT);
+        BOOST_CHECK_EQUAL(values.size(), 3);
+        BOOST_CHECK_EQUAL(*values[0], 30);
+        BOOST_CHECK_EQUAL(*values[1], 50);
+        BOOST_CHECK_EQUAL(*values[2], 70);
+
+        // Key 5 was read and written, so RAW intersection should exist
+        BOOST_CHECK(hasRAWIntersection(writerStorage, rwStorage));
+
+        co_return;
+    }());
+}
+
+// FIB-106: readSome with forward_range compiles and works correctly
+BOOST_AUTO_TEST_CASE(readSomeForwardRangeWorks)
+{
+    using Storage =
+        memory_storage::MemoryStorage<int, int, memory_storage::Attribute(memory_storage::ORDERED)>;
+
+    task::syncWait([]() -> task::Task<void> {
+        Storage backend;
+        ReadWriteSetStorage<decltype(backend)> rwStorage(backend);
+
+        // Write some data first
+        co_await storage2::writeOne(rwStorage, 1, 100);
+        co_await storage2::writeOne(rwStorage, 2, 200);
+        co_await storage2::writeOne(rwStorage, 3, 300);
+
+        // readSome with a vector (forward_range)
+        std::vector<int> keys = {1, 2, 3};
+        auto values = co_await storage2::readSome(rwStorage, keys);
+        BOOST_CHECK_EQUAL(values.size(), 3);
+        BOOST_CHECK_EQUAL(*values[0], 100);
+        BOOST_CHECK_EQUAL(*values[1], 200);
+        BOOST_CHECK_EQUAL(*values[2], 300);
+
+        co_return;
+    }());
+}
+
+// FIB-109: writeOne tracks key in write set only after co_await completes
+BOOST_AUTO_TEST_CASE(writeOneTracksAfterCompletion)
+{
+    using Storage =
+        memory_storage::MemoryStorage<int, int, memory_storage::Attribute(memory_storage::ORDERED)>;
+
+    task::syncWait([]() -> task::Task<void> {
+        Storage backend;
+        ReadWriteSetStorage<decltype(backend)> rwStorage(backend);
+
+        // After writeOne, the key should be in the write set
+        co_await storage2::writeOne(rwStorage, 10, 42);
+
+        auto const& rwSet = readWriteSet(rwStorage);
+        auto hash = std::hash<int>{}(10);
+        auto it = rwSet.find(hash);
+        BOOST_REQUIRE(it != rwSet.end());
+        BOOST_CHECK(it->second.write);
+
+        co_return;
+    }());
+}
+
+// FIB-100 + RAW: DIRECT reads create proper RAW intersections with writes
+BOOST_AUTO_TEST_CASE(directReadsCreateRAWIntersections)
+{
+    task::syncWait([]() -> task::Task<void> {
+        DirectMockStorage backend1;
+        ReadWriteSetStorage<decltype(backend1)> writer(backend1);
+
+        DirectMockStorage backend2;
+        ReadWriteSetStorage<decltype(backend2)> reader(backend2);
+
+        // Writer writes keys 10, 20, 30
+        co_await storage2::writeOne(writer, 10, 1);
+        co_await storage2::writeOne(writer, 20, 2);
+        co_await storage2::writeOne(writer, 30, 3);
+
+        // Reader does a DIRECT read of key 99 (not written)
+        co_await storage2::readOne(reader, 99, storage2::DIRECT);
+        BOOST_CHECK(!hasRAWIntersection(writer, reader));
+
+        // Reader does a DIRECT read of key 20 (was written)
+        co_await storage2::readOne(reader, 20, storage2::DIRECT);
+        BOOST_CHECK(hasRAWIntersection(writer, reader));
+
+        co_return;
+    }());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -18,6 +18,7 @@
   ],
   "overlay-ports": [
     "./ports/boost-context",
-    "./ports/tarscpp"
+    "./ports/tarscpp",
+    "./ports/rapidhash"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -51,6 +51,7 @@
     },
     "wedprcrypto",
     "range-v3",
+    "rapidhash",
     "hsm-crypto",
     {
       "name": "tarscpp",


### PR DESCRIPTION
## Summary
- **FIB-100**: Add `putSet(false, key)` tracking for `readSome`/`readOne` with DIRECT flag to prevent missed RAW dependencies
- **FIB-106**: Change range constraints from `input_range` to `forward_range` for `readSome`, `writeSome`, `removeSome` to prevent double-consumption of single-pass ranges
- **FIB-109**: Move write-set tracking to after `co_await` completion to prevent false RAW conflicts when writes are rolled back

## Test plan
- [x] DIRECT readOne is tracked in read set
- [x] DIRECT readSome is tracked in read set
- [x] hasRAWIntersection detects DIRECT reads
- [x] Write tracking deferred after co_await
- [x] Forward range constraint compiles correctly
- [x] All existing transaction-scheduler tests pass