### PR TITLE
feat: add air inspect admin ipc source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ test/*
 
 # Claude Code
 CLAUDE.local.md
+.worktrees/
 .claude/worktrees
 .claude/agents

--- a/docs/air_cli_inspect_manual.md
+++ b/docs/air_cli_inspect_manual.md
@@ -1,0 +1,649 @@
+# FISCO-BCOS Air CLI Inspect 操作手册
+
+本文档描述 `fisco-bcos air` 二进制中新增的本地只读 CLI 能力，重点面向运维和 AI agent 的手工验证。
+
+当前功能目标是让用户直接通过节点二进制执行：
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect ...
+```
+
+在不新增远程运维接口的前提下，读取当前节点视角的本地运行信息。
+
+## 1. 功能概览
+
+### 1.1 入口
+
+节点原有启动方式不变：
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis
+```
+
+新增 CLI 模式：
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect
+./fisco-bcos -c config.ini -g config.genesis -cli inspect <domain>
+```
+
+### 1.2 输出模式
+
+- 默认输出为人类可读文本
+- 加 `--json` 输出 JSON，便于 AI agent/脚本消费
+
+### 1.3 支持的 domain
+
+- `node`
+- `chain`
+- `network`
+- `storage`
+- `executor`
+- `logs`
+
+不带 domain 时返回总览视图。
+
+### 1.4 数据来源选择规则
+
+- 默认优先级：
+  - 若本地 Admin IPC 已开启且可达，使用 `admin-ipc`
+  - 否则自动退化到 `rpc+logs`
+- `admin-ipc` 默认关闭
+- `rpc+logs` 是 MVP 的兜底只读视图
+
+### 1.5 当前实现边界
+
+- 只支持本地节点视角
+- 只读，不修改节点状态
+- 不新增远程运维接口
+- `verbose` 和 `--source` 参数当前已解析，但暂未带来额外输出差异，可视为预留参数
+- fallback 模式下：
+  - `logs` 可真实读取本地日志
+  - 其他域部分为降级信息或配置视图
+- admin IPC 模式下：
+  - `node/chain/network/storage/executor/logs` 会尽量返回真实进程内状态
+  - `logs` 仍然读取本地日志文件，不直接读 boost log 内存缓冲
+
+## 2. 配置说明
+
+### 2.1 Admin IPC 开关
+
+支持以下两种配置名，任选其一即可：
+
+```ini
+[admin]
+enable=true
+ipc_path=./run/admin.sock
+```
+
+或：
+
+```ini
+[admin_ipc]
+enable=true
+path=./run/admin.sock
+```
+
+默认建议：
+
+```ini
+[admin]
+enable=false
+ipc_path=./run/admin.sock
+```
+
+### 2.2 相对路径解析规则
+
+`inspect` 相关路径会按 `config.ini` 所在目录解析，不按当前 shell 工作目录解析。
+
+当前已覆盖的相对路径包括：
+
+- `log.log_path`
+- `storage.data_path`
+- `admin.ipc_path`
+- `admin_ipc.path`
+
+例如：
+
+```ini
+[log]
+log_path=./log
+```
+
+如果配置文件在 `/data/node0/config.ini`，则 CLI 读取的实际日志目录是：
+
+```text
+/data/node0/log
+```
+
+## 3. 命令格式
+
+### 3.1 总览
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect
+```
+
+### 3.2 读取单个 domain
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect node
+./fisco-bcos -c config.ini -g config.genesis -cli inspect chain
+./fisco-bcos -c config.ini -g config.genesis -cli inspect network
+./fisco-bcos -c config.ini -g config.genesis -cli inspect storage
+./fisco-bcos -c config.ini -g config.genesis -cli inspect executor
+./fisco-bcos -c config.ini -g config.genesis -cli inspect logs
+```
+
+### 3.3 JSON 输出
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect --json
+./fisco-bcos -c config.ini -g config.genesis -cli inspect network --json
+```
+
+### 3.4 日志读取选项
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect logs --tail 100
+./fisco-bcos -c config.ini -g config.genesis -cli inspect logs --level INFO
+./fisco-bcos -c config.ini -g config.genesis -cli inspect logs --json --tail 50 --level ERROR
+```
+
+### 3.5 超时选项
+
+该参数主要用于访问进程内状态时的异步读取等待时间，单位毫秒：
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect chain --timeout 5000
+```
+
+### 3.6 预留参数
+
+当前可解析但暂未带来额外差异：
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect --verbose
+./fisco-bcos -c config.ini -g config.genesis -cli inspect --source
+```
+
+## 4. 输出字段说明
+
+### 4.1 顶层字段
+
+无论文本还是 JSON，核心语义一致：
+
+- `source`
+  - `admin-ipc` 表示来自本地进程内 IPC
+  - `rpc+logs` 表示 IPC 不可用，已退化到 fallback 模式
+- `command`
+  - 当前固定为 `inspect`
+- `domain`
+  - 指定 domain 时返回
+- `timestamp`
+  - CLI 生成响应的本地时间
+- `summary.latestBlock`
+- `summary.totalTx`
+- `warnings`
+
+### 4.2 section 结构
+
+每个 section 都是统一结构：
+
+- `available`
+- `reason`
+- `data`
+
+含义：
+
+- `available=true` 表示该 section 当前可提供有效数据
+- `available=false` 表示当前不可用或为降级视图
+- `reason` 解释不可用原因
+- `data` 为实际载荷
+
+## 5. 手工测试准备
+
+### 5.1 编译
+
+建议使用当前分支验证时已采用的构建参数：
+
+```bash
+cmake -S . -B build-make -G "Unix Makefiles" \
+  -DTESTS=ON \
+  -DWITH_TIKV=OFF \
+  -DWITH_TARS_SERVICES=OFF \
+  -DWITH_LIGHTNODE=OFF \
+  -DWITH_CPPSDK=OFF \
+  -DBUILD_STATIC=OFF \
+  -DWITH_WASM=OFF \
+  -DTOOLS=OFF
+
+cmake --build build-make --target fisco-bcos -j4
+```
+
+二进制路径：
+
+```text
+build-make/fisco-bcos-air/fisco-bcos
+```
+
+### 5.2 准备可启动节点目录
+
+你需要准备一套真实可运行的 air 节点目录，至少包含：
+
+- `config.ini`
+- `config.genesis`
+- 证书/私钥相关文件
+- 节点运行目录，如 `data/`、`log/`
+
+本文以下示例假设节点目录为：
+
+```text
+/path/to/node0/
+```
+
+对应：
+
+- `/path/to/node0/config.ini`
+- `/path/to/node0/config.genesis`
+
+## 6. 场景一：不开 Admin IPC，只验证 fallback
+
+这是最先应该验证的主流程。
+
+### 6.1 配置
+
+确保 `config.ini` 中关闭 admin IPC：
+
+```ini
+[admin]
+enable=false
+ipc_path=./run/admin.sock
+```
+
+或：
+
+```ini
+[admin_ipc]
+enable=false
+path=./run/admin.sock
+```
+
+### 6.2 启动节点
+
+```bash
+cd /path/to/node0
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis
+```
+
+### 6.3 验证总览命令
+
+另开一个终端：
+
+```bash
+cd /path/to/node0
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect
+```
+
+预期：
+
+- 命令成功返回
+- `Source` 或 JSON 中的 `source` 为 `rpc+logs`
+- 输出包含 warning，说明 admin IPC 不可用，已退化
+
+### 6.4 验证 domain 读取
+
+分别执行：
+
+```bash
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect node
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect chain
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect network
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect storage
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect executor
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect logs
+```
+
+预期：
+
+- `node/network/storage/logs` 通常能返回内容
+- `chain/executor` 在 fallback 下可能是降级或 unavailable
+- 结果中只显示所请求的单个 domain
+
+### 6.5 验证 JSON 输出
+
+```bash
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect --json
+```
+
+预期：
+
+- 输出为合法 JSON
+- `source` 为 `rpc+logs`
+- 有 `summary`、`warnings`、各 section 字段
+
+### 6.6 验证日志读取
+
+先确保 `log.log_path` 对应目录下已有节点日志。
+
+执行：
+
+```bash
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect logs --tail 20
+```
+
+再执行：
+
+```bash
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect logs --json --tail 20 --level INFO
+```
+
+预期：
+
+- 能读到最近日志
+- `--tail` 生效
+- `--level INFO` 仅保留包含 `INFO` 的日志行
+- JSON 输出里 `logs.data.entries` 为数组
+
+### 6.7 验证相对路径解析
+
+这一步重点验证不是按当前工作目录读日志。
+
+例如：
+
+```bash
+cd /tmp
+/path/to/build-make/fisco-bcos-air/fisco-bcos \
+  -c /path/to/node0/config.ini \
+  -g /path/to/node0/config.genesis \
+  -cli inspect logs --json --tail 10
+```
+
+预期：
+
+- 仍能正确读取 `/path/to/node0/log`
+- `logs.data.path` 是解析后的绝对路径或规范化路径
+- 不会因为当前 shell 在 `/tmp` 而找错日志目录
+
+## 7. 场景二：开启 Admin IPC，验证进程内视图
+
+### 7.1 修改配置
+
+在 `config.ini` 中开启：
+
+```ini
+[admin]
+enable=true
+ipc_path=./run/admin.sock
+```
+
+建议保留相对路径，方便验证配置目录锚定。
+
+### 7.2 启动节点
+
+```bash
+cd /path/to/node0
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis
+```
+
+### 7.3 验证 socket 文件创建
+
+```bash
+ls -l /path/to/node0/run/admin.sock
+```
+
+预期：
+
+- 文件存在
+- 权限为本地 Unix socket，代码中会尝试设置为 `0600`
+
+### 7.4 验证总览
+
+另开终端执行：
+
+```bash
+cd /path/to/node0
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect
+```
+
+预期：
+
+- `source=admin-ipc`
+- 无 fallback warning
+- `node/chain/network/storage/executor/logs` 中大部分应可用
+
+### 7.5 验证各 domain
+
+执行：
+
+```bash
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect node --json
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect chain --json
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect network --json
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect storage --json
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect executor --json
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect logs --json --tail 20
+```
+
+重点观察：
+
+- `node`
+  - `chainID`
+  - `groupID`
+  - `nodeName`
+  - `rpcService/gatewayService/executorService/txpoolService`
+  - `withoutTarsFramework`
+- `chain`
+  - `consensusType`
+  - `latestBlock`
+  - `totalTx`
+  - `pendingTxs`
+- `network`
+  - `rpc/web3/p2p` 监听地址
+  - `connectedNodeCount`
+  - `connectedNodes`
+- `storage`
+  - `type`
+  - `dataPath`
+  - `stateDBPath`
+  - `blockDBPath`
+- `executor`
+  - `schedulerAvailable`
+  - `storageAvailable`
+  - `ledgerAvailable`
+  - `baselineScheduler*`
+- `logs`
+  - 日志文件实际读取结果
+
+## 8. 场景三：开启配置但让 Admin IPC 不可达
+
+该场景用于验证自动退化逻辑。
+
+### 8.1 做法 A：节点未启动
+
+配置里保持：
+
+```ini
+[admin]
+enable=true
+ipc_path=./run/admin.sock
+```
+
+但不要启动节点，直接执行：
+
+```bash
+cd /path/to/node0
+../../build-make/fisco-bcos-air/fisco-bcos -c config.ini -g config.genesis -cli inspect --json
+```
+
+预期：
+
+- `source=rpc+logs`
+- 不会报成 `admin-ipc`
+- 有 fallback warning
+
+### 8.2 做法 B：删除 socket
+
+在节点退出后执行：
+
+```bash
+rm -f /path/to/node0/run/admin.sock
+```
+
+然后再次执行 CLI inspect。
+
+预期与上面一致：
+
+- 自动回退到 `rpc+logs`
+
+## 9. 场景四：异常输入验证
+
+### 9.1 缺少 CLI 子命令
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli
+```
+
+预期：
+
+- 失败
+- 提示 `cli command is required`
+
+### 9.2 不支持的 CLI 子命令
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli status
+```
+
+预期：
+
+- 失败
+- 提示 `unsupported cli command`
+
+### 9.3 位置参数过多
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect logs extra
+```
+
+预期：
+
+- 失败
+- 提示 `too many cli positional arguments`
+
+### 9.4 与其他 operation 冲突
+
+```bash
+./fisco-bcos -c config.ini -g config.genesis -cli inspect --prune
+```
+
+预期：
+
+- 直接拒绝
+- 提示 `cli mode can not be used with other operations`
+
+## 10. 人类可读输出和 JSON 输出示例
+
+### 10.1 文本人类可读示例
+
+```text
+Source: rpc+logs
+Command: inspect logs
+Timestamp: 2026-04-20 15:41:45
+Summary: latestBlock=degraded totalTx=degraded
+Warning: In-process admin IPC is unavailable; using source=rpc+logs degraded view.
+Logs: available data={
+  ...
+}
+```
+
+### 10.2 JSON 示例关键字段
+
+```json
+{
+  "source": "admin-ipc",
+  "command": "inspect",
+  "domain": "chain",
+  "timestamp": "2026-04-20 15:41:45",
+  "summary": {
+    "latestBlock": "123",
+    "totalTx": "456"
+  },
+  "chain": {
+    "available": true,
+    "data": {
+      "latestBlock": 123,
+      "totalTx": 456
+    }
+  },
+  "warnings": []
+}
+```
+
+## 11. 排障建议
+
+### 11.1 `source` 一直是 `rpc+logs`
+
+检查：
+
+- `config.ini` 中是否真的开启了 `admin.enable=true`
+- 节点是否已经启动
+- `ipc_path` 对应 socket 是否存在
+- CLI 使用的 `config.ini` 是否就是节点实际运行的那份
+
+### 11.2 `logs` 读不到内容
+
+检查：
+
+- `log.log_path` 是否正确
+- 日志目录中是否已有日志文件
+- `--level` 过滤是否过严
+- 是否在错误的配置目录上运行
+
+### 11.3 `chain`/`executor` 不可用
+
+如果 `source=rpc+logs`，这是预期内行为，属于降级视图。
+
+如果 `source=admin-ipc` 但仍然 unavailable，重点检查：
+
+- 节点是否完成初始化
+- 相关模块对象是否已建立
+- 是否存在 timeout，特别是 `--timeout` 设置过小
+
+## 12. 建议的验收清单
+
+建议按下面顺序验收：
+
+1. 编译成功
+2. `admin.enable=false` 时 `inspect --json` 返回 `source=rpc+logs`
+3. `inspect logs --json --tail N --level INFO` 能读到本地日志
+4. 从非节点工作目录执行 CLI，仍能正确解析相对路径
+5. `admin.enable=true` 并启动节点后，返回 `source=admin-ipc`
+6. `node/chain/network/storage/executor/logs` 六个 domain 都能单独调用
+7. 节点停掉后，再次调用自动退化到 `rpc+logs`
+
+## 13. 当前代码位置
+
+如果你后续手工调试代码，核心文件如下：
+
+- `libinitializer/CommandHelper.h`
+- `libinitializer/CommandHelper.cpp`
+- `fisco-bcos-air/main.cpp`
+- `fisco-bcos-air/AirNodeInitializer.h`
+- `fisco-bcos-air/AirNodeInitializer.cpp`
+- `fisco-bcos-air/cli/InspectConfig.h`
+- `fisco-bcos-air/cli/InspectConfig.cpp`
+- `fisco-bcos-air/cli/InspectApplication.h`
+- `fisco-bcos-air/cli/InspectApplication.cpp`
+- `fisco-bcos-air/cli/FallbackInspectors.h`
+- `fisco-bcos-air/cli/FallbackInspectors.cpp`
+- `fisco-bcos-air/cli/AdminIPCProtocol.h`
+- `fisco-bcos-air/cli/AdminIPCProtocol.cpp`
+- `fisco-bcos-air/cli/AdminIPCClient.h`
+- `fisco-bcos-air/cli/AdminIPCClient.cpp`
+- `fisco-bcos-air/cli/AdminIPCServer.h`
+- `fisco-bcos-air/cli/AdminIPCServer.cpp`
+- `fisco-bcos-air/cli/AdminInspectors.h`
+- `fisco-bcos-air/cli/AdminInspectors.cpp`
+- `tests/unittest/AirInspectCLITest.cpp`
+- `tests/unittest/CommandHelperTest.cpp`

--- a/docs/superpowers/plans/2026-04-20-air-cli-inspect-implementation.md
+++ b/docs/superpowers/plans/2026-04-20-air-cli-inspect-implementation.md
@@ -1,0 +1,577 @@
+# Air CLI Inspect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `./fisco-bcos -cli inspect` and `inspect <domain>` to the air node binary with human-readable output by default, `--json` output for automation, `admin-ipc` as an opt-in in-process source, and `rpc+logs` as the automatic fallback source.
+
+**Architecture:** Extend `libinitializer/CommandHelper` to parse CLI mode into a typed inspect request, branch `fisco-bcos-air/main.cpp` into node mode vs CLI mode, add a small inspect application layer under `fisco-bcos-air/cli/`, and keep data collection separate from rendering. Implement fallback inspection first, then add optional admin IPC server/client wiring so the same CLI request can choose `admin-ipc` when available.
+
+**Tech Stack:** C++17, Boost.Program_options, Boost.PropertyTree, JsonCpp, existing FISCO-BCOS local RPC/node runtime objects, Boost.Test, CMake.
+
+---
+
+### Task 1: Add CLI mode parsing and tests
+
+**Files:**
+- Modify: `libinitializer/CommandHelper.h`
+- Modify: `libinitializer/CommandHelper.cpp`
+- Modify: `fisco-bcos-air/main.cpp`
+- Create: `tests/unittest/CommandHelperTest.cpp`
+
+- [ ] **Step 1: Write the failing parsing tests**
+
+```cpp
+#include "libinitializer/CommandHelper.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos::initializer;
+
+BOOST_AUTO_TEST_CASE(parseInspectOverviewCli)
+{
+    const char* argv[] = {"fisco-bcos", "-c", "config.ini", "-g", "config.genesis", "-cli",
+        "inspect"};
+    auto params = initAirNodeCommandLine(static_cast<int>(std::size(argv)), argv, false);
+
+    BOOST_CHECK(params.cliMode);
+    BOOST_CHECK_EQUAL(params.cliRequest.command, "inspect");
+    BOOST_CHECK_EQUAL(params.cliRequest.domain, "");
+    BOOST_CHECK(!params.cliRequest.jsonOutput);
+}
+
+BOOST_AUTO_TEST_CASE(parseInspectDomainJsonCli)
+{
+    const char* argv[] = {"fisco-bcos", "-c", "config.ini", "-cli", "inspect", "network",
+        "--json", "--timeout", "2500"};
+    auto params = initAirNodeCommandLine(static_cast<int>(std::size(argv)), argv, false);
+
+    BOOST_CHECK(params.cliMode);
+    BOOST_CHECK_EQUAL(params.cliRequest.command, "inspect");
+    BOOST_CHECK_EQUAL(params.cliRequest.domain, "network");
+    BOOST_CHECK(params.cliRequest.jsonOutput);
+    BOOST_CHECK_EQUAL(params.cliRequest.timeoutMs, 2500);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Run: `ctest --test-dir build -R fisco-bcos-test --output-on-failure`
+
+Expected: build or test fails because `Params` does not contain CLI request fields yet.
+
+- [ ] **Step 3: Write the minimal parsing types and branch**
+
+```cpp
+struct CLIRequest
+{
+    std::string command;
+    std::string domain;
+    bool jsonOutput = false;
+    bool verbose = false;
+    bool showSource = false;
+    int timeoutMs = 3000;
+    std::optional<int> tail;
+    std::string logLevel;
+};
+
+struct Params
+{
+    std::string configFilePath;
+    std::string genesisFilePath;
+    std::string snapshotPath;
+    float txSpeed = 10;
+    bool cliMode = false;
+    CLIRequest cliRequest;
+    enum class operation : int { ... } op;
+};
+```
+
+```cpp
+main_options.add_options()("cli", "run inspect CLI mode")(
+    "json", "render inspect output as json")("verbose", "show more detail")(
+    "source", "always print selected source")(
+    "timeout", boost::program_options::value<int>()->default_value(3000),
+    "inspect timeout in milliseconds")(
+    "tail", boost::program_options::value<int>(), "tail N lines for inspect logs")(
+    "level", boost::program_options::value<std::string>(), "log level filter");
+
+auto parsed = boost::program_options::command_line_parser(argc, argv)
+                  .options(main_options)
+                  .allow_unregistered()
+                  .run();
+```
+
+```cpp
+if (params.cliMode)
+{
+    return runAirInspectCLI(params);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Run: `ctest --test-dir build -R fisco-bcos-test --output-on-failure`
+
+Expected: the new `CommandHelperTest` passes and existing command-line behavior still builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libinitializer/CommandHelper.h libinitializer/CommandHelper.cpp fisco-bcos-air/main.cpp tests/unittest/CommandHelperTest.cpp
+git commit -m "feat: parse air inspect cli mode"
+```
+
+### Task 2: Add inspect DTOs, renderers, and fallback source selection
+
+**Files:**
+- Create: `fisco-bcos-air/cli/InspectTypes.h`
+- Create: `fisco-bcos-air/cli/InspectTypes.cpp`
+- Create: `fisco-bcos-air/cli/InspectRenderer.h`
+- Create: `fisco-bcos-air/cli/InspectRenderer.cpp`
+- Create: `fisco-bcos-air/cli/InspectConfig.h`
+- Create: `fisco-bcos-air/cli/InspectConfig.cpp`
+- Create: `fisco-bcos-air/cli/InspectApplication.h`
+- Create: `fisco-bcos-air/cli/InspectApplication.cpp`
+- Modify: `fisco-bcos-air/CMakeLists.txt`
+- Test: `tests/unittest/CommandHelperTest.cpp`
+
+- [ ] **Step 1: Write the failing source-selection and rendering tests**
+
+```cpp
+BOOST_AUTO_TEST_CASE(renderHumanReadableOverview)
+{
+    bcos::air::cli::InspectResponse response;
+    response.source = "rpc+logs";
+    response.command = "inspect";
+    response.summary.latestBlock = "123";
+    response.summary.totalTx = "456";
+
+    auto rendered = bcos::air::cli::renderHumanReadable(response);
+    BOOST_CHECK(rendered.find("Source: rpc+logs") != std::string::npos);
+    BOOST_CHECK(rendered.find("latestBlock=123") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(selectsRpcAndLogsWhenAdminDisabled)
+{
+    auto config = bcos::air::cli::loadInspectConfig("tools/BcosAirBuilder/nodes/127.0.0.1/node0/config.ini");
+    BOOST_CHECK(!config.adminEnabled);
+    BOOST_CHECK_EQUAL(config.preferredSource(), "rpc+logs");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Expected: missing inspect types/config/renderer symbols.
+
+- [ ] **Step 3: Write minimal inspect DTOs and fallback application**
+
+```cpp
+namespace bcos::air::cli
+{
+struct InspectSection
+{
+    bool available = false;
+    std::string reason;
+    Json::Value data = Json::objectValue;
+};
+
+struct InspectResponse
+{
+    std::string source;
+    std::string command;
+    std::string timestamp;
+    InspectSection node;
+    InspectSection chain;
+    InspectSection network;
+    InspectSection storage;
+    InspectSection executor;
+    InspectSection logs;
+    struct Summary
+    {
+        std::string latestBlock;
+        std::string totalTx;
+    } summary;
+    std::vector<std::string> warnings;
+};
+}
+```
+
+```cpp
+class InspectConfig
+{
+public:
+    static InspectConfig load(const std::string& configPath);
+    std::string preferredSource() const { return adminEnabled ? "admin-ipc" : "rpc+logs"; }
+
+    bool adminEnabled = false;
+    std::string adminIPCPath;
+    std::string rpcListenIP;
+    int rpcListenPort = 20200;
+    bool web3Enabled = false;
+    std::string web3ListenIP;
+    int web3ListenPort = 8545;
+    std::string logPath;
+};
+```
+
+```cpp
+int runAirInspectCLI(const bcos::initializer::Params& params)
+{
+    auto config = bcos::air::cli::InspectConfig::load(params.configFilePath);
+    auto response = bcos::air::cli::InspectApplication(config).run(params.cliRequest);
+    std::cout << (params.cliRequest.jsonOutput ? renderJson(response) : renderHumanReadable(response))
+              << std::endl;
+    return 0;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Expected: inspect DTO and renderer tests pass, `fisco-bcos` still links.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fisco-bcos-air/CMakeLists.txt fisco-bcos-air/cli/InspectTypes.h fisco-bcos-air/cli/InspectTypes.cpp fisco-bcos-air/cli/InspectRenderer.h fisco-bcos-air/cli/InspectRenderer.cpp fisco-bcos-air/cli/InspectConfig.h fisco-bcos-air/cli/InspectConfig.cpp fisco-bcos-air/cli/InspectApplication.h fisco-bcos-air/cli/InspectApplication.cpp tests/unittest/CommandHelperTest.cpp
+git commit -m "feat: add inspect response model and fallback runner"
+```
+
+### Task 3: Implement `rpc+logs` inspectors for overview, domains, and degraded fields
+
+**Files:**
+- Create: `fisco-bcos-air/cli/FallbackInspectors.h`
+- Create: `fisco-bcos-air/cli/FallbackInspectors.cpp`
+- Modify: `fisco-bcos-air/cli/InspectApplication.cpp`
+- Test: `tests/unittest/CommandHelperTest.cpp`
+
+- [ ] **Step 1: Write the failing fallback inspection tests**
+
+```cpp
+BOOST_AUTO_TEST_CASE(logInspectorReadsConfiguredPath)
+{
+    bcos::air::cli::InspectConfig config;
+    config.logPath = "tools/BcosAirBuilder/nodes/127.0.0.1/node0/log";
+
+    auto response = bcos::air::cli::buildFallbackLogSection(config, std::nullopt, "");
+    BOOST_CHECK(response.available);
+    BOOST_CHECK(response.data.isObject());
+}
+
+BOOST_AUTO_TEST_CASE(executorSectionIsMarkedUnavailableInFallbackMode)
+{
+    auto section = bcos::air::cli::buildUnavailableExecutorFallbackSection();
+    BOOST_CHECK(!section.available);
+    BOOST_CHECK(section.reason.find("rpc+logs") != std::string::npos);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Expected: missing fallback inspector helpers.
+
+- [ ] **Step 3: Write the minimal fallback inspectors**
+
+```cpp
+InspectSection buildUnavailableExecutorFallbackSection()
+{
+    InspectSection section;
+    section.available = false;
+    section.reason = "internal executor state unavailable in source=rpc+logs";
+    section.data["source"] = "rpc+logs";
+    return section;
+}
+```
+
+```cpp
+InspectSection buildFallbackLogSection(
+    const InspectConfig& config, std::optional<int> tail, const std::string& levelFilter)
+{
+    InspectSection section;
+    section.available = true;
+    section.data["path"] = config.logPath;
+    section.data["tail"] = tail ? *tail : 0;
+    section.data["levelFilter"] = levelFilter;
+    return section;
+}
+```
+
+```cpp
+InspectResponse InspectApplication::runFallback(const CLIRequest& request)
+{
+    InspectResponse response;
+    response.source = "rpc+logs";
+    response.command = request.domain.empty() ? "inspect" : "inspect " + request.domain;
+    response.logs = buildFallbackLogSection(m_config, request.tail, request.logLevel);
+    response.executor = buildUnavailableExecutorFallbackSection();
+    response.storage = buildFallbackStorageSection(m_config);
+    response.network = buildFallbackNetworkSection(m_config);
+    response.chain = buildFallbackChainSection(m_config, request.timeoutMs);
+    return response;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Run: `ctest --test-dir build -R fisco-bcos-test --output-on-failure`
+
+Expected: fallback-domain tests pass and overview renders degraded fields explicitly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fisco-bcos-air/cli/FallbackInspectors.h fisco-bcos-air/cli/FallbackInspectors.cpp fisco-bcos-air/cli/InspectApplication.cpp tests/unittest/CommandHelperTest.cpp
+git commit -m "feat: add rpc and log fallback inspectors"
+```
+
+### Task 4: Add opt-in admin IPC config, protocol, server, and client selection
+
+**Files:**
+- Create: `fisco-bcos-air/cli/AdminIPCProtocol.h`
+- Create: `fisco-bcos-air/cli/AdminIPCProtocol.cpp`
+- Create: `fisco-bcos-air/cli/AdminIPCServer.h`
+- Create: `fisco-bcos-air/cli/AdminIPCServer.cpp`
+- Create: `fisco-bcos-air/cli/AdminIPCClient.h`
+- Create: `fisco-bcos-air/cli/AdminIPCClient.cpp`
+- Modify: `fisco-bcos-air/AirNodeInitializer.h`
+- Modify: `fisco-bcos-air/AirNodeInitializer.cpp`
+- Modify: `fisco-bcos-air/cli/InspectConfig.cpp`
+- Modify: `fisco-bcos-air/cli/InspectApplication.cpp`
+- Test: `tests/unittest/CommandHelperTest.cpp`
+
+- [ ] **Step 1: Write the failing admin-config and source-selection tests**
+
+```cpp
+BOOST_AUTO_TEST_CASE(selectsAdminIpcWhenEnabledAndReachable)
+{
+    bcos::air::cli::InspectConfig config;
+    config.adminEnabled = true;
+    config.adminIPCPath = "/tmp/fisco-bcos-admin.sock";
+
+    bcos::air::cli::InspectApplication app(config);
+    app.setAdminReachabilityForTest(true);
+    BOOST_CHECK_EQUAL(app.selectSource(), "admin-ipc");
+}
+
+BOOST_AUTO_TEST_CASE(fallsBackWhenAdminIpcUnavailable)
+{
+    bcos::air::cli::InspectConfig config;
+    config.adminEnabled = true;
+    config.adminIPCPath = "/tmp/missing.sock";
+
+    bcos::air::cli::InspectApplication app(config);
+    app.setAdminReachabilityForTest(false);
+    BOOST_CHECK_EQUAL(app.selectSource(), "rpc+logs");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Expected: missing admin protocol/client/server support.
+
+- [ ] **Step 3: Write the minimal admin IPC protocol and wiring**
+
+```cpp
+struct AdminInspectRequest
+{
+    std::string command;
+    std::string domain;
+    bool jsonOutput = false;
+    bool verbose = false;
+    int timeoutMs = 3000;
+};
+
+struct AdminInspectReply
+{
+    bool ok = false;
+    Json::Value payload = Json::objectValue;
+    std::string error;
+};
+```
+
+```cpp
+class AdminIPCServer
+{
+public:
+    void start(const InspectConfig& config, std::function<Json::Value(const AdminInspectRequest&)> handler);
+    void stop();
+};
+```
+
+```cpp
+class AdminIPCClient
+{
+public:
+    bool reachable(const std::string& socketPath) const;
+    AdminInspectReply request(const std::string& socketPath, const AdminInspectRequest& request) const;
+};
+```
+
+```cpp
+if (config.adminEnabled && m_adminClient.reachable(config.adminIPCPath))
+{
+    return runAdminIPC(request);
+}
+return runFallback(request);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Expected: source selection prefers admin IPC when reachable and falls back cleanly otherwise.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fisco-bcos-air/cli/AdminIPCProtocol.h fisco-bcos-air/cli/AdminIPCProtocol.cpp fisco-bcos-air/cli/AdminIPCServer.h fisco-bcos-air/cli/AdminIPCServer.cpp fisco-bcos-air/cli/AdminIPCClient.h fisco-bcos-air/cli/AdminIPCClient.cpp fisco-bcos-air/AirNodeInitializer.h fisco-bcos-air/AirNodeInitializer.cpp fisco-bcos-air/cli/InspectConfig.cpp fisco-bcos-air/cli/InspectApplication.cpp tests/unittest/CommandHelperTest.cpp
+git commit -m "feat: add opt-in admin ipc inspect path"
+```
+
+### Task 5: Expose in-process admin inspectors and verify the binary build
+
+**Files:**
+- Create: `fisco-bcos-air/cli/AdminInspectors.h`
+- Create: `fisco-bcos-air/cli/AdminInspectors.cpp`
+- Modify: `fisco-bcos-air/cli/AdminIPCServer.cpp`
+- Modify: `fisco-bcos-air/cli/InspectTypes.cpp`
+- Modify: `fisco-bcos-air/main.cpp`
+- Test: `tests/unittest/CommandHelperTest.cpp`
+
+- [ ] **Step 1: Write the failing in-process inspection tests**
+
+```cpp
+BOOST_AUTO_TEST_CASE(adminExecutorSectionReportsAvailableWhenInitializerPresent)
+{
+    auto section = bcos::air::cli::buildAdminExecutorSectionForTest(true);
+    BOOST_CHECK(section.available);
+    BOOST_CHECK(section.data.isObject());
+}
+
+BOOST_AUTO_TEST_CASE(adminStorageSectionIncludesStorageType)
+{
+    auto section = bcos::air::cli::buildAdminStorageSectionForTest("RocksDB");
+    BOOST_CHECK_EQUAL(section.data["storageType"].asString(), "RocksDB");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Expected: missing admin inspector builders.
+
+- [ ] **Step 3: Write the minimal admin inspectors**
+
+```cpp
+InspectSection buildAdminExecutorSection(const bcos::initializer::Initializer& initializer)
+{
+    InspectSection section;
+    section.available = initializer.scheduler() != nullptr;
+    section.data["schedulerAvailable"] = initializer.scheduler() != nullptr;
+    section.data["txpoolAvailable"] = initializer.txPoolInitializer() != nullptr;
+    return section;
+}
+```
+
+```cpp
+InspectSection buildAdminStorageSection(const bcos::initializer::Initializer& initializer)
+{
+    InspectSection section;
+    section.available = initializer.storage() != nullptr;
+    section.data["storageType"] = initializer.nodeConfig()->storageType();
+    section.data["statePath"] = initializer.nodeConfig()->storagePath();
+    return section;
+}
+```
+
+```cpp
+Json::Value AdminIPCServer::handleInspect(const AdminInspectRequest& request)
+{
+    InspectResponse response;
+    response.source = "admin-ipc";
+    response.executor = buildAdminExecutorSection(*m_initializer);
+    response.storage = buildAdminStorageSection(*m_initializer);
+    return toJson(response);
+}
+```
+
+- [ ] **Step 4: Run test and binary build to verify it passes**
+
+Run: `cmake --build build --target fisco-bcos-test fisco-bcos -j4`
+
+Expected: inspect tests pass and the `fisco-bcos` binary links with the new CLI sources.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fisco-bcos-air/cli/AdminInspectors.h fisco-bcos-air/cli/AdminInspectors.cpp fisco-bcos-air/cli/AdminIPCServer.cpp fisco-bcos-air/cli/InspectTypes.cpp fisco-bcos-air/main.cpp tests/unittest/CommandHelperTest.cpp
+git commit -m "feat: expose in-process admin inspect summaries"
+```
+
+### Task 6: Final verification and PR preparation
+
+**Files:**
+- Modify: none unless fixes are required
+
+- [ ] **Step 1: Run targeted verification**
+
+Run: `cmake --build build --target fisco-bcos -j4`
+
+Run: `cmake --build build --target fisco-bcos-test -j4`
+
+Run: `ctest --test-dir build -R fisco-bcos-test --output-on-failure`
+
+Expected: binary and test target build successfully and the new command parsing / inspect tests pass.
+
+- [ ] **Step 2: Run manual smoke commands**
+
+Run: `./build/fisco-bcos/fisco-bcos -c tools/BcosAirBuilder/nodes/127.0.0.1/node0/config.ini -g tools/BcosAirBuilder/nodes/127.0.0.1/node0/config.genesis -cli inspect --json`
+
+Run: `./build/fisco-bcos/fisco-bcos -c tools/BcosAirBuilder/nodes/127.0.0.1/node0/config.ini -cli inspect logs --tail 5`
+
+Expected: first command prints structured JSON with `source`, second command prints human-readable log diagnostics.
+
+- [ ] **Step 3: Inspect git diff before PR**
+
+Run: `git status --short`
+
+Run: `git diff --stat`
+
+Expected: only planned worktree files are modified.
+
+- [ ] **Step 4: Push branch and prepare PR**
+
+Run: `git push -u origin feat/air-cli-inspect`
+
+Expected: branch is published to `origin`.
+
+- [ ] **Step 5: Create PR summary**
+
+```text
+Title: feat: add air node inspect cli with admin ipc fallback
+
+Summary:
+- add -cli inspect and inspect <domain> commands to fisco-bcos air binary
+- default to human-readable output with --json support
+- add opt-in local admin ipc for in-process inspection
+- fall back to rpc plus logs when admin ipc is disabled or unreachable
+```
+
+## Self-Review
+
+- Spec coverage: the plan covers CLI parsing, human-readable and JSON output, overview and domain commands, opt-in admin IPC, fallback to `rpc+logs`, and read-only behavior.
+- Placeholder scan: no `TODO`, `TBD`, or “implement later” markers remain.
+- Type consistency: `CLIRequest`, `InspectConfig`, `InspectResponse`, and `AdminInspectRequest` names are consistent across tasks.

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -19,6 +19,8 @@
  * @date 2021-10-28
  */
 #include "AirNodeInitializer.h"
+#include "cli/AdminInspectors.h"
+#include "cli/InspectConfig.h"
 #include "libinitializer/Common.h"
 #include <bcos-boostssl/websocket/RawWsMessage.h>
 #include <bcos-crypto/signature/key/KeyFactoryImpl.h>
@@ -45,6 +47,7 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
 
     boost::property_tree::ptree ptree;
     boost::property_tree::read_ini(_configFilePath, ptree);
+    m_adminInspectConfig = bcos::air::cli::InspectConfig::load(_configFilePath);
 
     m_logInitializer = std::make_shared<BoostLogInitializer>();
     m_logInitializer->initLog(_configFilePath);
@@ -150,12 +153,26 @@ void AirNodeInitializer::start()
 
         started.wait(false);
     }
+
+    if (m_adminInspectConfig && m_adminInspectConfig->adminEnabled)
+    {
+        m_adminIPCServer = std::make_shared<bcos::air::cli::AdminIPCServer>();
+        m_adminIPCServer->start(*m_adminInspectConfig, [this](const auto& request) {
+            return bcos::air::cli::buildAdminInspectReply(
+                request, *m_adminInspectConfig, *m_nodeInitializer, m_rpc, m_gateway);
+        });
+    }
 }
 
 void AirNodeInitializer::stop()
 {
     try
     {
+        if (m_adminIPCServer)
+        {
+            m_adminIPCServer->stop();
+            m_adminIPCServer.reset();
+        }
         if (m_rpc)
         {
             m_rpc->stop();

--- a/fisco-bcos-air/AirNodeInitializer.h
+++ b/fisco-bcos-air/AirNodeInitializer.h
@@ -20,6 +20,7 @@
  */
 
 #pragma once
+#include "cli/AdminIPCServer.h"
 #include "libinitializer/Initializer.h"
 #include <bcos-framework/gateway/GatewayInterface.h>
 #include <bcos-framework/rpc/RPCInterface.h>
@@ -43,6 +44,8 @@ public:
     virtual void start();
     virtual void stop();
     virtual bcos::initializer::Initializer::Ptr nodeInitializer() { return m_nodeInitializer; }
+    virtual bcos::rpc::RPCInterface::Ptr rpc() { return m_rpc; }
+    virtual bcos::gateway::GatewayInterface::Ptr gateway() { return m_gateway; }
 
 protected:
     virtual void initAirNode(std::string const& _configFilePath, std::string const& _genesisFile,
@@ -64,5 +67,7 @@ private:
     std::optional<rpc::RPCApplication> m_tarsApplication;
     std::optional<std::string> m_tarsConfig;
     std::optional<std::thread> m_tarsThread;
+    std::shared_ptr<bcos::air::cli::AdminIPCServer> m_adminIPCServer;
+    std::optional<bcos::air::cli::InspectConfig> m_adminInspectConfig;
 };
 }  // namespace bcos::node

--- a/fisco-bcos-air/CMakeLists.txt
+++ b/fisco-bcos-air/CMakeLists.txt
@@ -1,6 +1,20 @@
+find_package(Boost REQUIRED filesystem)
+find_package(jsoncpp CONFIG REQUIRED)
+
+set(AIR_CLI_TARGET air-cli)
+add_library(${AIR_CLI_TARGET}
+    cli/FallbackInspectors.cpp
+    cli/InspectApplication.cpp
+    cli/InspectConfig.cpp
+    cli/InspectRenderer.cpp
+    cli/InspectTypes.cpp)
+target_include_directories(${AIR_CLI_TARGET} PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(${AIR_CLI_TARGET} PUBLIC ${COMMAND_HELPER_LIB} JsonCpp::JsonCpp)
+
 aux_source_directory(. SRC_LIST)
 
 set(BINARY_NAME fisco-bcos)
 add_executable(${BINARY_NAME} ${SRC_LIST})
-target_link_libraries(${BINARY_NAME} PUBLIC ${INIT_LIB} ${PBFT_INIT_LIB} ${COMMAND_HELPER_LIB} ${GATEWAY_TARGET})
+target_link_libraries(${BINARY_NAME} PUBLIC ${INIT_LIB} ${PBFT_INIT_LIB} ${COMMAND_HELPER_LIB}
+    ${GATEWAY_TARGET} ${AIR_CLI_TARGET})
 set_target_properties(${BINARY_NAME} PROPERTIES UNITY_BUILD "ON")

--- a/fisco-bcos-air/CMakeLists.txt
+++ b/fisco-bcos-air/CMakeLists.txt
@@ -3,13 +3,18 @@ find_package(jsoncpp CONFIG REQUIRED)
 
 set(AIR_CLI_TARGET air-cli)
 add_library(${AIR_CLI_TARGET}
+    cli/AdminIPCClient.cpp
+    cli/AdminInspectors.cpp
+    cli/AdminIPCProtocol.cpp
+    cli/AdminIPCServer.cpp
     cli/FallbackInspectors.cpp
     cli/InspectApplication.cpp
     cli/InspectConfig.cpp
     cli/InspectRenderer.cpp
     cli/InspectTypes.cpp)
 target_include_directories(${AIR_CLI_TARGET} PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(${AIR_CLI_TARGET} PUBLIC ${COMMAND_HELPER_LIB} JsonCpp::JsonCpp)
+target_link_libraries(${AIR_CLI_TARGET} PUBLIC ${COMMAND_HELPER_LIB} ${INIT_LIB}
+    ${PBFT_INIT_LIB} JsonCpp::JsonCpp)
 
 aux_source_directory(. SRC_LIST)
 

--- a/fisco-bcos-air/cli/AdminIPCClient.cpp
+++ b/fisco-bcos-air/cli/AdminIPCClient.cpp
@@ -1,4 +1,5 @@
 #include "AdminIPCClient.h"
+#include <sys/socket.h>
 #include <boost/asio/connect.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/read.hpp>
@@ -33,24 +34,24 @@ std::string readAll(Socket& socket)
     }
     return payload;
 }
+
+void setNoSigPipe(Socket& socket)
+{
+#ifdef SO_NOSIGPIPE
+    int enable = 1;
+    ::setsockopt(socket.native_handle(), SOL_SOCKET, SO_NOSIGPIPE, &enable, sizeof(enable));
+#endif
+}
 }  // namespace
 
 namespace bcos::air::cli
 {
 bool AdminIPCClient::reachable(const std::string& socketPath) const
 {
-    try
-    {
-        boost::asio::io_context io;
-        Socket socket(io);
-        socket.connect(Endpoint(socketPath));
-        socket.close();
-        return true;
-    }
-    catch (...)
-    {
-        return false;
-    }
+    AdminInspectRequest request;
+    request.command = "inspect";
+    request.timeoutMs = 500;
+    return this->request(socketPath, request).ok;
 }
 
 AdminInspectReply AdminIPCClient::request(
@@ -61,6 +62,7 @@ AdminInspectReply AdminIPCClient::request(
         boost::asio::io_context io;
         Socket socket(io);
         socket.connect(Endpoint(socketPath));
+        setNoSigPipe(socket);
 
         auto payload = serializeAdminInspectRequest(request);
         payload.push_back('\n');

--- a/fisco-bcos-air/cli/AdminIPCClient.cpp
+++ b/fisco-bcos-air/cli/AdminIPCClient.cpp
@@ -1,0 +1,79 @@
+#include "AdminIPCClient.h"
+#include <boost/asio/connect.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/write.hpp>
+#include <sstream>
+
+namespace
+{
+using Socket = boost::asio::local::stream_protocol::socket;
+using Endpoint = boost::asio::local::stream_protocol::endpoint;
+
+std::string readAll(Socket& socket)
+{
+    std::string payload;
+    boost::system::error_code ec;
+    for (;;)
+    {
+        char buffer[1024] = {0};
+        auto bytesRead = socket.read_some(boost::asio::buffer(buffer), ec);
+        if (bytesRead > 0)
+        {
+            payload.append(buffer, bytesRead);
+        }
+        if (ec == boost::asio::error::eof)
+        {
+            break;
+        }
+        if (ec)
+        {
+            throw boost::system::system_error(ec);
+        }
+    }
+    return payload;
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+bool AdminIPCClient::reachable(const std::string& socketPath) const
+{
+    try
+    {
+        boost::asio::io_context io;
+        Socket socket(io);
+        socket.connect(Endpoint(socketPath));
+        socket.close();
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+AdminInspectReply AdminIPCClient::request(
+    const std::string& socketPath, const AdminInspectRequest& request) const
+{
+    try
+    {
+        boost::asio::io_context io;
+        Socket socket(io);
+        socket.connect(Endpoint(socketPath));
+
+        auto payload = serializeAdminInspectRequest(request);
+        payload.push_back('\n');
+        boost::asio::write(socket, boost::asio::buffer(payload));
+        socket.shutdown(boost::asio::socket_base::shutdown_send);
+
+        return deserializeAdminInspectReply(readAll(socket));
+    }
+    catch (const std::exception& e)
+    {
+        AdminInspectReply reply;
+        reply.error = e.what();
+        return reply;
+    }
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/AdminIPCClient.h
+++ b/fisco-bcos-air/cli/AdminIPCClient.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "AdminIPCProtocol.h"
+#include <string>
+
+namespace bcos::air::cli
+{
+class AdminIPCClient
+{
+public:
+    bool reachable(const std::string& socketPath) const;
+    AdminInspectReply request(
+        const std::string& socketPath, const AdminInspectRequest& request) const;
+};
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/AdminIPCProtocol.cpp
+++ b/fisco-bcos-air/cli/AdminIPCProtocol.cpp
@@ -1,0 +1,105 @@
+#include "AdminIPCProtocol.h"
+
+namespace
+{
+std::string writeJson(const Json::Value& value)
+{
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    return Json::writeString(builder, value);
+}
+
+Json::Value readJson(const std::string& payload)
+{
+    Json::CharReaderBuilder builder;
+    Json::Value root;
+    std::string errors;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    if (!reader->parse(payload.data(), payload.data() + payload.size(), &root, &errors))
+    {
+        throw std::runtime_error("invalid admin ipc payload: " + errors);
+    }
+    return root;
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+Json::Value toJson(const AdminInspectRequest& request)
+{
+    Json::Value value(Json::objectValue);
+    value["command"] = request.command;
+    value["domain"] = request.domain;
+    value["jsonOutput"] = request.jsonOutput;
+    value["verbose"] = request.verbose;
+    value["showSource"] = request.showSource;
+    value["timeoutMs"] = request.timeoutMs;
+    if (request.tail)
+    {
+        value["tail"] = *request.tail;
+    }
+    if (!request.logLevel.empty())
+    {
+        value["logLevel"] = request.logLevel;
+    }
+    return value;
+}
+
+Json::Value toJson(const AdminInspectReply& reply)
+{
+    Json::Value value(Json::objectValue);
+    value["ok"] = reply.ok;
+    value["payload"] = reply.payload;
+    if (!reply.error.empty())
+    {
+        value["error"] = reply.error;
+    }
+    return value;
+}
+
+AdminInspectRequest adminInspectRequestFromJson(const Json::Value& json)
+{
+    AdminInspectRequest request;
+    request.command = json["command"].asString();
+    request.domain = json["domain"].asString();
+    request.jsonOutput = json.get("jsonOutput", false).asBool();
+    request.verbose = json.get("verbose", false).asBool();
+    request.showSource = json.get("showSource", false).asBool();
+    request.timeoutMs = json.get("timeoutMs", 3000).asInt();
+    if (json.isMember("tail"))
+    {
+        request.tail = json["tail"].asInt();
+    }
+    request.logLevel = json.get("logLevel", "").asString();
+    return request;
+}
+
+AdminInspectReply adminInspectReplyFromJson(const Json::Value& json)
+{
+    AdminInspectReply reply;
+    reply.ok = json.get("ok", false).asBool();
+    reply.payload = json["payload"];
+    reply.error = json.get("error", "").asString();
+    return reply;
+}
+
+std::string serializeAdminInspectRequest(const AdminInspectRequest& request)
+{
+    return writeJson(toJson(request));
+}
+
+std::string serializeAdminInspectReply(const AdminInspectReply& reply)
+{
+    return writeJson(toJson(reply));
+}
+
+AdminInspectRequest deserializeAdminInspectRequest(const std::string& payload)
+{
+    return adminInspectRequestFromJson(readJson(payload));
+}
+
+AdminInspectReply deserializeAdminInspectReply(const std::string& payload)
+{
+    return adminInspectReplyFromJson(readJson(payload));
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/AdminIPCProtocol.h
+++ b/fisco-bcos-air/cli/AdminIPCProtocol.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <json/json.h>
+#include <optional>
+#include <string>
+
+namespace bcos::air::cli
+{
+struct AdminInspectRequest
+{
+    std::string command;
+    std::string domain;
+    bool jsonOutput = false;
+    bool verbose = false;
+    bool showSource = false;
+    int timeoutMs = 3000;
+    std::optional<int> tail;
+    std::string logLevel;
+};
+
+struct AdminInspectReply
+{
+    bool ok = false;
+    Json::Value payload = Json::objectValue;
+    std::string error;
+};
+
+Json::Value toJson(const AdminInspectRequest& request);
+Json::Value toJson(const AdminInspectReply& reply);
+
+AdminInspectRequest adminInspectRequestFromJson(const Json::Value& json);
+AdminInspectReply adminInspectReplyFromJson(const Json::Value& json);
+
+std::string serializeAdminInspectRequest(const AdminInspectRequest& request);
+std::string serializeAdminInspectReply(const AdminInspectReply& reply);
+
+AdminInspectRequest deserializeAdminInspectRequest(const std::string& payload);
+AdminInspectReply deserializeAdminInspectReply(const std::string& payload);
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/AdminIPCServer.cpp
+++ b/fisco-bcos-air/cli/AdminIPCServer.cpp
@@ -1,0 +1,165 @@
+#include "AdminIPCServer.h"
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <filesystem>
+
+namespace
+{
+constexpr int c_invalidFD = -1;
+
+std::string readRequestLine(int fd)
+{
+    std::string payload;
+    char ch = '\0';
+    while (true)
+    {
+        auto bytesRead = ::read(fd, &ch, 1);
+        if (bytesRead <= 0)
+        {
+            break;
+        }
+        if (ch == '\n')
+        {
+            break;
+        }
+        payload.push_back(ch);
+    }
+    return payload;
+}
+
+void writeAll(int fd, const std::string& payload)
+{
+    size_t offset = 0;
+    while (offset < payload.size())
+    {
+        auto written = ::write(fd, payload.data() + offset, payload.size() - offset);
+        if (written <= 0)
+        {
+            return;
+        }
+        offset += static_cast<size_t>(written);
+    }
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+void AdminIPCServer::start(const InspectConfig& config, Handler handler)
+{
+    stop();
+    if (!config.adminEnabled || config.adminIPCPath.empty())
+    {
+        return;
+    }
+
+    namespace fs = std::filesystem;
+    fs::create_directories(fs::path(config.adminIPCPath).parent_path());
+    ::unlink(config.adminIPCPath.c_str());
+
+    m_serverFD = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (m_serverFD == c_invalidFD)
+    {
+        throw std::runtime_error("failed to create admin ipc socket");
+    }
+
+    sockaddr_un address{};
+    address.sun_family = AF_UNIX;
+    if (config.adminIPCPath.size() >= sizeof(address.sun_path))
+    {
+        ::close(m_serverFD);
+        m_serverFD = c_invalidFD;
+        throw std::runtime_error("admin ipc path is too long");
+    }
+    std::snprintf(address.sun_path, sizeof(address.sun_path), "%s", config.adminIPCPath.c_str());
+    if (::bind(m_serverFD, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0)
+    {
+        ::close(m_serverFD);
+        m_serverFD = c_invalidFD;
+        throw std::runtime_error("failed to bind admin ipc socket");
+    }
+    ::chmod(config.adminIPCPath.c_str(), 0600);
+    if (::listen(m_serverFD, 16) != 0)
+    {
+        ::close(m_serverFD);
+        m_serverFD = c_invalidFD;
+        throw std::runtime_error("failed to listen on admin ipc socket");
+    }
+
+    m_socketPath = config.adminIPCPath;
+    m_handler = std::move(handler);
+    m_running = true;
+    m_thread.emplace([this]() { runAcceptLoop(); });
+}
+
+void AdminIPCServer::stop()
+{
+    if (!m_running && m_serverFD == c_invalidFD)
+    {
+        return;
+    }
+
+    m_running = false;
+    if (m_serverFD != c_invalidFD)
+    {
+        ::shutdown(m_serverFD, SHUT_RDWR);
+        ::close(m_serverFD);
+        m_serverFD = c_invalidFD;
+    }
+    if (m_thread && m_thread->joinable())
+    {
+        m_thread->join();
+    }
+    m_thread.reset();
+
+    if (!m_socketPath.empty())
+    {
+        ::unlink(m_socketPath.c_str());
+    }
+    m_socketPath.clear();
+}
+
+void AdminIPCServer::runAcceptLoop()
+{
+    while (m_running)
+    {
+        auto clientFD = ::accept(m_serverFD, nullptr, nullptr);
+        if (clientFD == c_invalidFD)
+        {
+            if (m_running)
+            {
+                continue;
+            }
+            break;
+        }
+        handleConnection(clientFD);
+        ::close(clientFD);
+    }
+}
+
+void AdminIPCServer::handleConnection(int nativeSocket)
+{
+    AdminInspectReply reply;
+    try
+    {
+        auto payload = readRequestLine(nativeSocket);
+        auto request = deserializeAdminInspectRequest(payload);
+        if (!m_handler)
+        {
+            reply.error = "admin ipc handler is not configured";
+        }
+        else
+        {
+            reply = m_handler(request);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        reply.ok = false;
+        reply.error = e.what();
+    }
+
+    writeAll(nativeSocket, serializeAdminInspectReply(reply));
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/AdminIPCServer.cpp
+++ b/fisco-bcos-air/cli/AdminIPCServer.cpp
@@ -34,13 +34,27 @@ void writeAll(int fd, const std::string& payload)
     size_t offset = 0;
     while (offset < payload.size())
     {
+#ifdef MSG_NOSIGNAL
+        auto written = ::send(fd, payload.data() + offset, payload.size() - offset, MSG_NOSIGNAL);
+#else
         auto written = ::write(fd, payload.data() + offset, payload.size() - offset);
+#endif
         if (written <= 0)
         {
             return;
         }
         offset += static_cast<size_t>(written);
     }
+}
+
+void setNoSigPipe(int fd)
+{
+#ifdef SO_NOSIGPIPE
+    int enable = 1;
+    ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &enable, sizeof(enable));
+#else
+    (void)fd;
+#endif
 }
 }  // namespace
 
@@ -140,10 +154,16 @@ void AdminIPCServer::runAcceptLoop()
 
 void AdminIPCServer::handleConnection(int nativeSocket)
 {
+    setNoSigPipe(nativeSocket);
+
     AdminInspectReply reply;
     try
     {
         auto payload = readRequestLine(nativeSocket);
+        if (payload.empty())
+        {
+            return;
+        }
         auto request = deserializeAdminInspectRequest(payload);
         if (!m_handler)
         {

--- a/fisco-bcos-air/cli/AdminIPCServer.h
+++ b/fisco-bcos-air/cli/AdminIPCServer.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "AdminIPCProtocol.h"
+#include "InspectConfig.h"
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace bcos::air::cli
+{
+class AdminIPCServer
+{
+public:
+    using Handler = std::function<AdminInspectReply(const AdminInspectRequest&)>;
+
+    AdminIPCServer() = default;
+    AdminIPCServer(const AdminIPCServer&) = delete;
+    AdminIPCServer(AdminIPCServer&&) = delete;
+    AdminIPCServer& operator=(const AdminIPCServer&) = delete;
+    AdminIPCServer& operator=(AdminIPCServer&&) = delete;
+    ~AdminIPCServer() { stop(); }
+
+    void start(const InspectConfig& config, Handler handler);
+    void stop();
+
+private:
+    void runAcceptLoop();
+    void handleConnection(int nativeSocket);
+
+    std::atomic_bool m_running = false;
+    std::optional<std::thread> m_thread;
+    std::string m_socketPath;
+    Handler m_handler;
+    int m_serverFD = -1;
+};
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/AdminInspectors.cpp
+++ b/fisco-bcos-air/cli/AdminInspectors.cpp
@@ -1,0 +1,323 @@
+#include "AdminInspectors.h"
+#include "FallbackInspectors.h"
+#include <future>
+
+namespace
+{
+using namespace std::chrono_literals;
+
+bcos::air::cli::InspectSection makeUnavailableSection(const std::string& reason)
+{
+    bcos::air::cli::InspectSection section;
+    section.available = false;
+    section.reason = reason;
+    return section;
+}
+
+template <class T>
+std::optional<T> waitForFuture(std::future<T>& future, int timeoutMs)
+{
+    if (future.wait_for(std::chrono::milliseconds(timeoutMs)) != std::future_status::ready)
+    {
+        return std::nullopt;
+    }
+    return future.get();
+}
+
+struct LedgerSummary
+{
+    bool ok = false;
+    std::string error;
+    int64_t totalTx = 0;
+    int64_t failedTx = 0;
+    bcos::protocol::BlockNumber latestBlock = -1;
+};
+
+struct PendingTxSummary
+{
+    bool ok = false;
+    std::string error;
+    uint64_t pendingTxs = 0;
+};
+
+LedgerSummary fetchLedgerSummary(const bcos::ledger::LedgerInterface::Ptr& ledger, int timeoutMs)
+{
+    if (!ledger)
+    {
+        return {.error = "ledger is not available"};
+    }
+
+    auto promise = std::make_shared<std::promise<LedgerSummary>>();
+    auto future = promise->get_future();
+    ledger->asyncGetTotalTransactionCount(
+        [promise](bcos::Error::Ptr error, int64_t totalTx, int64_t failedTx,
+            bcos::protocol::BlockNumber latestBlock) mutable {
+            LedgerSummary summary;
+            if (error)
+            {
+                summary.error = error->errorMessage();
+            }
+            else
+            {
+                summary.ok = true;
+                summary.totalTx = totalTx;
+                summary.failedTx = failedTx;
+                summary.latestBlock = latestBlock;
+            }
+            promise->set_value(std::move(summary));
+        });
+
+    auto result = waitForFuture(future, timeoutMs);
+    if (!result)
+    {
+        return {.error = "timed out while reading ledger summary"};
+    }
+    return *result;
+}
+
+PendingTxSummary fetchPendingTxSummary(
+    const bcos::txpool::TxPoolInterface::Ptr& txpool, int timeoutMs)
+{
+    if (!txpool)
+    {
+        return {.error = "txpool is not available"};
+    }
+
+    auto promise = std::make_shared<std::promise<PendingTxSummary>>();
+    auto future = promise->get_future();
+    txpool->asyncGetPendingTransactionSize(
+        [promise](bcos::Error::Ptr error, uint64_t pendingTxs) mutable {
+            PendingTxSummary summary;
+            if (error)
+            {
+                summary.error = error->errorMessage();
+            }
+            else
+            {
+                summary.ok = true;
+                summary.pendingTxs = pendingTxs;
+            }
+            promise->set_value(std::move(summary));
+        });
+
+    auto result = waitForFuture(future, timeoutMs);
+    if (!result)
+    {
+        return {.error = "timed out while reading txpool summary"};
+    }
+    return *result;
+}
+
+Json::Value buildNodeData(const bcos::tool::NodeConfig::Ptr& nodeConfig,
+    const bcos::group::ChainNodeInfo::Ptr& nodeInfo, bool hasRPC, bool hasGateway)
+{
+    Json::Value data(Json::objectValue);
+    data["chainID"] = nodeConfig->chainId();
+    data["groupID"] = nodeConfig->groupId();
+    data["nodeName"] = nodeConfig->nodeName();
+    data["nodeType"] = nodeInfo ? static_cast<int>(nodeInfo->nodeType()) : 0;
+    data["nodeID"] = nodeInfo ? nodeInfo->nodeID() : "";
+    data["smCryptoType"] = nodeConfig->smCryptoType();
+    data["wasm"] = nodeConfig->isWasm();
+    data["authCheck"] = nodeConfig->isAuthCheck();
+    data["withoutTarsFramework"] = nodeConfig->withoutTarsFramework();
+    data["compatibilityVersion"] = nodeConfig->compatibilityVersionStr();
+    data["rpcService"] = nodeConfig->rpcServiceName();
+    data["gatewayService"] = nodeConfig->gatewayServiceName();
+    data["schedulerService"] = nodeConfig->schedulerServiceName();
+    data["executorService"] = nodeConfig->executorServiceName();
+    data["txpoolService"] = nodeConfig->txpoolServiceName();
+    data["rpcObject"] = hasRPC;
+    data["gatewayObject"] = hasGateway;
+    return data;
+}
+
+Json::Value buildChainData(const bcos::tool::NodeConfig::Ptr& nodeConfig,
+    const LedgerSummary& ledgerSummary, const PendingTxSummary& pendingSummary)
+{
+    Json::Value data(Json::objectValue);
+    data["chainID"] = nodeConfig->chainId();
+    data["groupID"] = nodeConfig->groupId();
+    data["consensusType"] = nodeConfig->consensusType();
+    data["blockLimit"] = Json::UInt64(nodeConfig->blockLimit());
+    data["epochSealerNum"] = Json::Int64(nodeConfig->epochSealerNum());
+    data["epochBlockNum"] = Json::Int64(nodeConfig->epochBlockNum());
+    if (ledgerSummary.ok)
+    {
+        data["latestBlock"] = Json::Int64(ledgerSummary.latestBlock);
+        data["totalTx"] = Json::Int64(ledgerSummary.totalTx);
+        data["failedTx"] = Json::Int64(ledgerSummary.failedTx);
+    }
+    if (pendingSummary.ok)
+    {
+        data["pendingTxs"] = Json::UInt64(pendingSummary.pendingTxs);
+    }
+    return data;
+}
+
+Json::Value buildNetworkData(const bcos::tool::NodeConfig::Ptr& nodeConfig,
+    const bcos::group::GroupInfo::Ptr& groupInfo,
+    const bcos::gateway::GroupNodeInfo::Ptr& groupNodeInfo)
+{
+    Json::Value data(Json::objectValue);
+    data["rpcListenIP"] = nodeConfig->rpcListenIP();
+    data["rpcListenPort"] = nodeConfig->rpcListenPort();
+    data["web3Enabled"] = nodeConfig->enableWeb3Rpc();
+    data["web3ListenIP"] = nodeConfig->web3RpcListenIP();
+    data["web3ListenPort"] = nodeConfig->web3RpcListenPort();
+    data["p2pListenIP"] = nodeConfig->p2pListenIP();
+    data["p2pListenPort"] = nodeConfig->p2pListenPort();
+    data["gatewayService"] = nodeConfig->gatewayServiceName();
+    data["rpcService"] = nodeConfig->rpcServiceName();
+    data["groupInfoNodeCount"] = Json::Int64(groupInfo ? groupInfo->nodesNum() : 0);
+    data["connectedNodeCount"] =
+        Json::UInt64(groupNodeInfo ? groupNodeInfo->nodeIDList().size() : 0);
+
+    Json::Value connectedNodes(Json::arrayValue);
+    if (groupNodeInfo)
+    {
+        for (const auto& nodeID : groupNodeInfo->nodeIDList())
+        {
+            connectedNodes.append(nodeID);
+        }
+    }
+    data["connectedNodes"] = std::move(connectedNodes);
+    return data;
+}
+
+Json::Value buildStorageData(const bcos::tool::NodeConfig::Ptr& nodeConfig)
+{
+    Json::Value data(Json::objectValue);
+    data["type"] = nodeConfig->storageType();
+    data["dataPath"] = nodeConfig->storagePath();
+    data["stateDBPath"] = nodeConfig->stateDBPath();
+    data["blockDBPath"] = nodeConfig->blockDBPath();
+    data["enableSeparateBlockAndState"] = nodeConfig->enableSeparateBlockAndState();
+    data["enableArchive"] = nodeConfig->enableArchive();
+    data["syncArchivedBlocks"] = nodeConfig->syncArchivedBlocks();
+    data["storageSecurityEnable"] = nodeConfig->storageSecurityEnable();
+    return data;
+}
+
+Json::Value buildExecutorData(
+    const bcos::tool::NodeConfig::Ptr& nodeConfig, bcos::initializer::Initializer& initializer)
+{
+    Json::Value data(Json::objectValue);
+    data["schedulerAvailable"] = static_cast<bool>(initializer.scheduler());
+    data["storageAvailable"] = static_cast<bool>(initializer.storage());
+    data["ledgerAvailable"] = static_cast<bool>(initializer.ledger());
+    data["serialExecute"] = nodeConfig->isSerialExecute();
+    data["vmCacheSize"] = Json::UInt64(nodeConfig->vmCacheSize());
+    data["executorService"] = nodeConfig->executorServiceName();
+    data["baselineSchedulerParallel"] = nodeConfig->baselineSchedulerConfig().parallel;
+    data["baselineSchedulerGrainSize"] = nodeConfig->baselineSchedulerConfig().grainSize;
+    data["baselineSchedulerMaxThread"] = nodeConfig->baselineSchedulerConfig().maxThread;
+    return data;
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+InspectResponse buildAdminInspectResponse(const AdminInspectRequest& request,
+    const InspectConfig& config, bcos::initializer::Initializer& initializer,
+    const bcos::rpc::RPCInterface::Ptr& rpc, const bcos::gateway::GatewayInterface::Ptr& gateway)
+{
+    InspectResponse response;
+    response.source = "admin-ipc";
+    response.command = request.command;
+    response.domain = request.domain;
+
+    auto nodeConfig = initializer.nodeConfig();
+    if (!nodeConfig)
+    {
+        response.node = makeUnavailableSection("node config is not available");
+        response.chain = makeUnavailableSection("node config is not available");
+        response.network = makeUnavailableSection("node config is not available");
+        response.storage = makeUnavailableSection("node config is not available");
+        response.executor = makeUnavailableSection("node config is not available");
+        response.logs = buildFallbackLogSection(config, request.tail, request.logLevel);
+        response.summary.latestBlock = "unavailable";
+        response.summary.totalTx = "unavailable";
+        response.warnings.emplace_back("admin-ipc handler is running before node config is ready");
+        return response;
+    }
+
+    auto pbftInitializer = initializer.pbftInitializer();
+    auto groupInfo = pbftInitializer ? pbftInitializer->groupInfo() : nullptr;
+    auto nodeInfo = pbftInitializer ? pbftInitializer->nodeInfo() : nullptr;
+    auto frontInitializer = initializer.frontService();
+    auto front = frontInitializer ? frontInitializer->front() : nullptr;
+    auto groupNodeInfo = front ? front->groupNodeInfo() : nullptr;
+    auto txPoolInitializer = initializer.txPoolInitializer();
+    auto txpool = txPoolInitializer ? txPoolInitializer->txpool() : nullptr;
+
+    auto ledgerSummary = fetchLedgerSummary(initializer.ledger(), request.timeoutMs);
+    auto pendingSummary = fetchPendingTxSummary(txpool, request.timeoutMs);
+
+    response.summary.latestBlock =
+        ledgerSummary.ok ? std::to_string(ledgerSummary.latestBlock) : "unavailable";
+    response.summary.totalTx =
+        ledgerSummary.ok ? std::to_string(ledgerSummary.totalTx) : "unavailable";
+
+    response.node.available = true;
+    response.node.data =
+        buildNodeData(nodeConfig, nodeInfo, static_cast<bool>(rpc), static_cast<bool>(gateway));
+
+    if (ledgerSummary.ok)
+    {
+        response.chain.available = true;
+        response.chain.data = buildChainData(nodeConfig, ledgerSummary, pendingSummary);
+    }
+    else
+    {
+        response.chain = makeUnavailableSection(ledgerSummary.error);
+        response.chain.data = buildChainData(nodeConfig, ledgerSummary, pendingSummary);
+        response.warnings.emplace_back("chain summary unavailable: " + ledgerSummary.error);
+    }
+
+    response.network.available = true;
+    response.network.data = buildNetworkData(nodeConfig, groupInfo, groupNodeInfo);
+    if (!groupNodeInfo)
+    {
+        response.network.reason = "peer topology cache is not populated yet";
+    }
+
+    response.storage.available = true;
+    response.storage.data = buildStorageData(nodeConfig);
+
+    response.executor.available =
+        static_cast<bool>(initializer.scheduler()) || static_cast<bool>(initializer.storage());
+    response.executor.reason =
+        response.executor.available ? "" : "scheduler and storage are not available";
+    response.executor.data = buildExecutorData(nodeConfig, initializer);
+
+    response.logs = buildFallbackLogSection(config, request.tail, request.logLevel);
+
+    if (!pendingSummary.ok)
+    {
+        response.warnings.emplace_back(
+            "pending transaction summary unavailable: " + pendingSummary.error);
+    }
+
+    return response;
+}
+
+AdminInspectReply buildAdminInspectReply(const AdminInspectRequest& request,
+    const InspectConfig& config, bcos::initializer::Initializer& initializer,
+    const bcos::rpc::RPCInterface::Ptr& rpc, const bcos::gateway::GatewayInterface::Ptr& gateway)
+{
+    AdminInspectReply reply;
+    try
+    {
+        reply.ok = true;
+        reply.payload =
+            toJson(buildAdminInspectResponse(request, config, initializer, rpc, gateway));
+    }
+    catch (const std::exception& e)
+    {
+        reply.ok = false;
+        reply.error = e.what();
+    }
+    return reply;
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/AdminInspectors.h
+++ b/fisco-bcos-air/cli/AdminInspectors.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "AdminIPCProtocol.h"
+#include "InspectConfig.h"
+#include "InspectTypes.h"
+#include "libinitializer/Initializer.h"
+#include <bcos-framework/gateway/GatewayInterface.h>
+#include <bcos-framework/rpc/RPCInterface.h>
+
+namespace bcos::air::cli
+{
+InspectResponse buildAdminInspectResponse(const AdminInspectRequest& request,
+    const InspectConfig& config, bcos::initializer::Initializer& initializer,
+    const bcos::rpc::RPCInterface::Ptr& rpc, const bcos::gateway::GatewayInterface::Ptr& gateway);
+
+AdminInspectReply buildAdminInspectReply(const AdminInspectRequest& request,
+    const InspectConfig& config, bcos::initializer::Initializer& initializer,
+    const bcos::rpc::RPCInterface::Ptr& rpc, const bcos::gateway::GatewayInterface::Ptr& gateway);
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/FallbackInspectors.cpp
+++ b/fisco-bcos-air/cli/FallbackInspectors.cpp
@@ -1,0 +1,138 @@
+#include "FallbackInspectors.h"
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+namespace
+{
+std::vector<std::string> readLogLines(
+    const std::string& logPath, std::optional<int> tail, const std::string& levelFilter)
+{
+    namespace fs = std::filesystem;
+    std::vector<std::string> lines;
+    std::error_code ec;
+    fs::path path(logPath);
+    if (!fs::exists(path, ec))
+    {
+        return lines;
+    }
+
+    std::vector<fs::path> files;
+    if (fs::is_regular_file(path, ec))
+    {
+        files.push_back(path);
+    }
+    else if (fs::is_directory(path, ec))
+    {
+        for (const auto& entry : fs::directory_iterator(path, ec))
+        {
+            if (entry.is_regular_file(ec))
+            {
+                files.push_back(entry.path());
+            }
+        }
+    }
+
+    std::sort(files.begin(), files.end());
+    for (const auto& file : files)
+    {
+        std::ifstream in(file);
+        std::string line;
+        while (std::getline(in, line))
+        {
+            if (!levelFilter.empty() && line.find(levelFilter) == std::string::npos)
+            {
+                continue;
+            }
+            lines.push_back(line);
+        }
+    }
+
+    if (tail && *tail > 0 && static_cast<size_t>(*tail) < lines.size())
+    {
+        lines.erase(lines.begin(), lines.end() - *tail);
+    }
+    return lines;
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+InspectSection buildFallbackNodeSection(const InspectConfig& config)
+{
+    InspectSection section;
+    section.available = true;
+    section.data["preferredSource"] = config.preferredSource();
+    section.data["chainID"] = config.chainID;
+    section.data["rpcService"] = config.rpcServiceName;
+    return section;
+}
+
+InspectSection buildFallbackChainSection(const InspectConfig& config, int timeoutMs)
+{
+    InspectSection section;
+    section.available = false;
+    section.reason = "chain runtime state is degraded in source=rpc+logs";
+    section.data["chainID"] = config.chainID;
+    section.data["timeoutMs"] = timeoutMs;
+    section.data["rpcEndpoint"] = config.rpcListenIP + ":" + std::to_string(config.rpcListenPort);
+    return section;
+}
+
+InspectSection buildFallbackNetworkSection(const InspectConfig& config)
+{
+    InspectSection section;
+    section.available = true;
+    section.data["rpcListenIP"] = config.rpcListenIP;
+    section.data["rpcListenPort"] = config.rpcListenPort;
+    section.data["web3Enabled"] = config.web3Enabled;
+    section.data["web3ListenIP"] = config.web3ListenIP;
+    section.data["web3ListenPort"] = config.web3ListenPort;
+    section.data["gatewayService"] = config.gatewayServiceName;
+    return section;
+}
+
+InspectSection buildFallbackStorageSection(const InspectConfig& config)
+{
+    InspectSection section;
+    section.available = true;
+    section.data["dataPath"] = config.storagePath;
+    section.data["type"] = config.storageType;
+    return section;
+}
+
+InspectSection buildFallbackLogSection(
+    const InspectConfig& config, std::optional<int> tail, const std::string& levelFilter)
+{
+    InspectSection section;
+    section.data["path"] = config.logPath;
+    section.data["tail"] = tail ? *tail : 0;
+    section.data["levelFilter"] = levelFilter;
+
+    const auto lines = readLogLines(config.logPath, tail, levelFilter);
+    if (lines.empty())
+    {
+        section.available = false;
+        section.reason = "no readable log entries found in source=rpc+logs";
+        return section;
+    }
+
+    section.available = true;
+    Json::Value entries(Json::arrayValue);
+    for (const auto& line : lines)
+    {
+        entries.append(line);
+    }
+    section.data["entries"] = std::move(entries);
+    return section;
+}
+
+InspectSection buildUnavailableExecutorFallbackSection()
+{
+    InspectSection section;
+    section.available = false;
+    section.reason = "internal executor state unavailable in source=rpc+logs";
+    section.data["source"] = "rpc+logs";
+    return section;
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/FallbackInspectors.h
+++ b/fisco-bcos-air/cli/FallbackInspectors.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "InspectConfig.h"
+#include "InspectTypes.h"
+#include <optional>
+#include <string>
+
+namespace bcos::air::cli
+{
+InspectSection buildFallbackNodeSection(const InspectConfig& config);
+InspectSection buildFallbackChainSection(const InspectConfig& config, int timeoutMs);
+InspectSection buildFallbackNetworkSection(const InspectConfig& config);
+InspectSection buildFallbackStorageSection(const InspectConfig& config);
+InspectSection buildFallbackLogSection(
+    const InspectConfig& config, std::optional<int> tail, const std::string& levelFilter);
+InspectSection buildUnavailableExecutorFallbackSection();
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectApplication.cpp
+++ b/fisco-bcos-air/cli/InspectApplication.cpp
@@ -62,16 +62,26 @@ void keepOnlyRequestedDomain(const std::string& domain, bcos::air::cli::InspectR
 
 namespace bcos::air::cli
 {
-std::string InspectApplication::selectSource(const InspectConfig& config)
+InspectApplication::InspectApplication(const bcos::initializer::Params& params)
+  : m_params(params), m_config(InspectConfig::load(params.configFilePath))
+{}
+
+InspectApplication::InspectApplication(InspectConfig config) : m_config(std::move(config)) {}
+
+std::string InspectApplication::selectSource() const
 {
-    return config.preferredSource();
+    if (m_config.adminEnabled && adminReachable())
+    {
+        return "admin-ipc";
+    }
+    return "rpc+logs";
 }
 
 InspectResponse InspectApplication::buildResponse(
     const bcos::initializer::CLIRequest& request, const InspectConfig& config)
 {
     InspectResponse response;
-    response.source = selectSource(config);
+    response.source = "rpc+logs";
     response.command = request.command;
     response.domain = request.domain;
     response.timestamp = nowAsString();
@@ -90,10 +100,85 @@ InspectResponse InspectApplication::buildResponse(
     return response;
 }
 
+bool InspectApplication::adminReachable() const
+{
+    if (m_adminReachabilityForTest)
+    {
+        return *m_adminReachabilityForTest;
+    }
+    return m_adminClient.reachable(m_config.adminIPCPath);
+}
+
+AdminInspectRequest InspectApplication::buildAdminRequest() const
+{
+    AdminInspectRequest request;
+    request.command = m_params.cliRequest.command;
+    request.domain = m_params.cliRequest.domain;
+    request.jsonOutput = m_params.cliRequest.jsonOutput;
+    request.verbose = m_params.cliRequest.verbose;
+    request.showSource = m_params.cliRequest.showSource;
+    request.timeoutMs = m_params.cliRequest.timeoutMs;
+    request.tail = m_params.cliRequest.tail;
+    request.logLevel = m_params.cliRequest.logLevel;
+    return request;
+}
+
+InspectResponse InspectApplication::runFallback() const
+{
+    return buildResponse(m_params.cliRequest, m_config);
+}
+
+InspectResponse InspectApplication::runAdminIPC() const
+{
+    auto reply = m_adminClient.request(m_config.adminIPCPath, buildAdminRequest());
+    if (!reply.ok)
+    {
+        auto response = runFallback();
+        response.source = "rpc+logs";
+        response.warnings.emplace_back("admin-ipc request failed: " + reply.error);
+        return response;
+    }
+
+    InspectResponse response;
+    response.source = reply.payload.get("source", "admin-ipc").asString();
+    response.command = reply.payload.get("command", m_params.cliRequest.command).asString();
+    response.domain = reply.payload.get("domain", m_params.cliRequest.domain).asString();
+    response.timestamp = reply.payload.get("timestamp", nowAsString()).asString();
+    response.summary.latestBlock = reply.payload["summary"].get("latestBlock", "").asString();
+    response.summary.totalTx = reply.payload["summary"].get("totalTx", "").asString();
+
+    auto loadSection = [](const Json::Value& payload, const char* name) {
+        InspectSection section;
+        if (payload.isMember(name))
+        {
+            auto const& json = payload[name];
+            section.available = json.get("available", false).asBool();
+            section.reason = json.get("reason", "").asString();
+            section.data = json.get("data", Json::objectValue);
+        }
+        return section;
+    };
+
+    response.node = loadSection(reply.payload, "node");
+    response.chain = loadSection(reply.payload, "chain");
+    response.network = loadSection(reply.payload, "network");
+    response.storage = loadSection(reply.payload, "storage");
+    response.executor = loadSection(reply.payload, "executor");
+    response.logs = loadSection(reply.payload, "logs");
+    if (reply.payload.isMember("warnings") && reply.payload["warnings"].isArray())
+    {
+        for (const auto& warning : reply.payload["warnings"])
+        {
+            response.warnings.emplace_back(warning.asString());
+        }
+    }
+    keepOnlyRequestedDomain(response.domain, response);
+    return response;
+}
+
 int InspectApplication::run() const
 {
-    auto config = InspectConfig::load(m_params.configFilePath);
-    auto response = buildResponse(m_params.cliRequest, config);
+    auto response = selectSource() == "admin-ipc" ? runAdminIPC() : runFallback();
     std::cout << renderInspectResponse(response, m_params.cliRequest.jsonOutput) << std::endl;
     return 0;
 }

--- a/fisco-bcos-air/cli/InspectApplication.cpp
+++ b/fisco-bcos-air/cli/InspectApplication.cpp
@@ -1,0 +1,105 @@
+#include "InspectApplication.h"
+#include "FallbackInspectors.h"
+#include "InspectRenderer.h"
+#include <ctime>
+#include <iostream>
+
+namespace
+{
+std::string nowAsString()
+{
+    std::time_t now = std::time(nullptr);
+    std::tm currentTime{};
+    localtime_r(&now, &currentTime);
+
+    char buffer[32] = {0};
+    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &currentTime);
+    return buffer;
+}
+
+bcos::air::cli::InspectSection makeUnavailableSection(const std::string& reason)
+{
+    bcos::air::cli::InspectSection section;
+    section.available = false;
+    section.reason = reason;
+    return section;
+}
+
+void keepOnlyRequestedDomain(const std::string& domain, bcos::air::cli::InspectResponse& response)
+{
+    if (domain.empty())
+    {
+        return;
+    }
+
+    const auto hidden = makeUnavailableSection("");
+    if (domain != "node")
+    {
+        response.node = hidden;
+    }
+    if (domain != "chain")
+    {
+        response.chain = hidden;
+    }
+    if (domain != "network")
+    {
+        response.network = hidden;
+    }
+    if (domain != "storage")
+    {
+        response.storage = hidden;
+    }
+    if (domain != "executor")
+    {
+        response.executor = hidden;
+    }
+    if (domain != "logs")
+    {
+        response.logs = hidden;
+    }
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+std::string InspectApplication::selectSource(const InspectConfig& config)
+{
+    return config.preferredSource();
+}
+
+InspectResponse InspectApplication::buildResponse(
+    const bcos::initializer::CLIRequest& request, const InspectConfig& config)
+{
+    InspectResponse response;
+    response.source = selectSource(config);
+    response.command = request.command;
+    response.domain = request.domain;
+    response.timestamp = nowAsString();
+    response.summary.latestBlock = "degraded";
+    response.summary.totalTx = "degraded";
+    response.warnings.emplace_back(
+        "In-process admin IPC is unavailable; using source=rpc+logs degraded view.");
+
+    response.node = buildFallbackNodeSection(config);
+    response.chain = buildFallbackChainSection(config, request.timeoutMs);
+    response.network = buildFallbackNetworkSection(config);
+    response.storage = buildFallbackStorageSection(config);
+    response.executor = buildUnavailableExecutorFallbackSection();
+    response.logs = buildFallbackLogSection(config, request.tail, request.logLevel);
+    keepOnlyRequestedDomain(request.domain, response);
+    return response;
+}
+
+int InspectApplication::run() const
+{
+    auto config = InspectConfig::load(m_params.configFilePath);
+    auto response = buildResponse(m_params.cliRequest, config);
+    std::cout << renderInspectResponse(response, m_params.cliRequest.jsonOutput) << std::endl;
+    return 0;
+}
+
+int runAirInspectCLI(const bcos::initializer::Params& params)
+{
+    return InspectApplication(params).run();
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectApplication.h
+++ b/fisco-bcos-air/cli/InspectApplication.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "InspectConfig.h"
+#include "InspectTypes.h"
+#include "libinitializer/CommandHelper.h"
+
+namespace bcos::air::cli
+{
+class InspectApplication
+{
+public:
+    explicit InspectApplication(const bcos::initializer::Params& params) : m_params(params) {}
+
+    int run() const;
+
+    static std::string selectSource(const InspectConfig& config);
+    static InspectResponse buildResponse(
+        const bcos::initializer::CLIRequest& request, const InspectConfig& config);
+
+private:
+    bcos::initializer::Params m_params;
+};
+
+int runAirInspectCLI(const bcos::initializer::Params& params);
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectApplication.h
+++ b/fisco-bcos-air/cli/InspectApplication.h
@@ -1,24 +1,38 @@
 #pragma once
 
+#include "AdminIPCClient.h"
+#include "AdminIPCProtocol.h"
 #include "InspectConfig.h"
 #include "InspectTypes.h"
 #include "libinitializer/CommandHelper.h"
+#include <optional>
 
 namespace bcos::air::cli
 {
 class InspectApplication
 {
 public:
-    explicit InspectApplication(const bcos::initializer::Params& params) : m_params(params) {}
+    explicit InspectApplication(const bcos::initializer::Params& params);
+    explicit InspectApplication(InspectConfig config);
 
+    void setAdminReachabilityForTest(bool reachable) { m_adminReachabilityForTest = reachable; }
+
+    std::string selectSource() const;
     int run() const;
 
-    static std::string selectSource(const InspectConfig& config);
     static InspectResponse buildResponse(
         const bcos::initializer::CLIRequest& request, const InspectConfig& config);
 
 private:
+    bool adminReachable() const;
+    InspectResponse runFallback() const;
+    InspectResponse runAdminIPC() const;
+    AdminInspectRequest buildAdminRequest() const;
+
     bcos::initializer::Params m_params;
+    InspectConfig m_config;
+    AdminIPCClient m_adminClient;
+    std::optional<bool> m_adminReachabilityForTest;
 };
 
 int runAirInspectCLI(const bcos::initializer::Params& params);

--- a/fisco-bcos-air/cli/InspectConfig.cpp
+++ b/fisco-bcos-air/cli/InspectConfig.cpp
@@ -1,0 +1,61 @@
+#include "InspectConfig.h"
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+namespace
+{
+template <class T>
+T getConfigValue(const boost::property_tree::ptree& pt, const std::string& primaryKey,
+    const std::string& fallbackKey, const T& defaultValue)
+{
+    if (const auto value = pt.get_optional<T>(primaryKey); value)
+    {
+        return *value;
+    }
+    if (!fallbackKey.empty())
+    {
+        if (const auto value = pt.get_optional<T>(fallbackKey); value)
+        {
+            return *value;
+        }
+    }
+    return defaultValue;
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+std::string InspectConfig::preferredSource() const
+{
+    return adminEnabled ? "admin-ipc" : "rpc+logs";
+}
+
+InspectConfig InspectConfig::load(const std::string& configPath)
+{
+    boost::property_tree::ptree pt;
+    boost::property_tree::ini_parser::read_ini(configPath, pt);
+
+    InspectConfig config;
+    config.rpcListenIP = pt.get<std::string>("rpc.listen_ip", config.rpcListenIP);
+    config.rpcListenPort = pt.get<int>("rpc.listen_port", config.rpcListenPort);
+    config.web3Enabled = pt.get<bool>("web3_rpc.enable", config.web3Enabled);
+    config.web3ListenIP = pt.get<std::string>("web3_rpc.listen_ip", config.web3ListenIP);
+    config.web3ListenPort = pt.get<int>("web3_rpc.listen_port", config.web3ListenPort);
+    config.chainID = pt.get<std::string>("chain.chain_id", config.chainID);
+    config.rpcServiceName = pt.get<std::string>("service.rpc", config.rpcServiceName);
+    config.gatewayServiceName = pt.get<std::string>("service.gateway", config.gatewayServiceName);
+    config.storagePath = pt.get<std::string>("storage.data_path", config.storagePath);
+    config.storageType = pt.get<std::string>("storage.type", config.storageType);
+    config.logPath = pt.get<std::string>("log.log_path", config.logPath);
+    config.adminEnabled =
+        getConfigValue<bool>(pt, "admin.enable", "admin_ipc.enable", config.adminEnabled);
+    config.adminIPCPath =
+        getConfigValue<std::string>(pt, "admin.ipc_path", "admin_ipc.path", config.adminIPCPath);
+    return config;
+}
+
+InspectConfig loadInspectConfig(const std::string& configPath)
+{
+    return InspectConfig::load(configPath);
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectConfig.cpp
+++ b/fisco-bcos-air/cli/InspectConfig.cpp
@@ -1,6 +1,7 @@
 #include "InspectConfig.h"
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <filesystem>
 
 namespace
 {
@@ -21,6 +22,26 @@ T getConfigValue(const boost::property_tree::ptree& pt, const std::string& prima
     }
     return defaultValue;
 }
+
+std::string resolvePath(const std::filesystem::path& baseDir, const std::string& rawPath)
+{
+    if (rawPath.empty())
+    {
+        return rawPath;
+    }
+
+    std::filesystem::path path(rawPath);
+    if (path.is_absolute())
+    {
+        return path.lexically_normal().string();
+    }
+
+    if (baseDir.empty())
+    {
+        return path.lexically_normal().string();
+    }
+    return (baseDir / path).lexically_normal().string();
+}
 }  // namespace
 
 namespace bcos::air::cli
@@ -34,6 +55,7 @@ InspectConfig InspectConfig::load(const std::string& configPath)
 {
     boost::property_tree::ptree pt;
     boost::property_tree::ini_parser::read_ini(configPath, pt);
+    auto baseDir = std::filesystem::path(configPath).parent_path();
 
     InspectConfig config;
     config.rpcListenIP = pt.get<std::string>("rpc.listen_ip", config.rpcListenIP);
@@ -44,13 +66,14 @@ InspectConfig InspectConfig::load(const std::string& configPath)
     config.chainID = pt.get<std::string>("chain.chain_id", config.chainID);
     config.rpcServiceName = pt.get<std::string>("service.rpc", config.rpcServiceName);
     config.gatewayServiceName = pt.get<std::string>("service.gateway", config.gatewayServiceName);
-    config.storagePath = pt.get<std::string>("storage.data_path", config.storagePath);
+    config.storagePath =
+        resolvePath(baseDir, pt.get<std::string>("storage.data_path", config.storagePath));
     config.storageType = pt.get<std::string>("storage.type", config.storageType);
-    config.logPath = pt.get<std::string>("log.log_path", config.logPath);
+    config.logPath = resolvePath(baseDir, pt.get<std::string>("log.log_path", config.logPath));
     config.adminEnabled =
         getConfigValue<bool>(pt, "admin.enable", "admin_ipc.enable", config.adminEnabled);
-    config.adminIPCPath =
-        getConfigValue<std::string>(pt, "admin.ipc_path", "admin_ipc.path", config.adminIPCPath);
+    config.adminIPCPath = resolvePath(baseDir,
+        getConfigValue<std::string>(pt, "admin.ipc_path", "admin_ipc.path", config.adminIPCPath));
     return config;
 }
 

--- a/fisco-bcos-air/cli/InspectConfig.h
+++ b/fisco-bcos-air/cli/InspectConfig.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+namespace bcos::air::cli
+{
+struct InspectConfig
+{
+    bool adminEnabled = false;
+    std::string adminIPCPath = "./run/admin.sock";
+    std::string rpcListenIP = "127.0.0.1";
+    int rpcListenPort = 20200;
+    bool web3Enabled = false;
+    std::string web3ListenIP = "127.0.0.1";
+    int web3ListenPort = 8545;
+    std::string chainID = "chain0";
+    std::string rpcServiceName;
+    std::string gatewayServiceName;
+    std::string storagePath = "data";
+    std::string storageType = "RocksDB";
+    std::string logPath = "./log";
+
+    std::string preferredSource() const;
+    static InspectConfig load(const std::string& configPath);
+};
+
+InspectConfig loadInspectConfig(const std::string& configPath);
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectRenderer.cpp
+++ b/fisco-bcos-air/cli/InspectRenderer.cpp
@@ -1,0 +1,78 @@
+#include "InspectRenderer.h"
+#include <json/json.h>
+#include <sstream>
+
+namespace
+{
+std::string writeJson(const Json::Value& value)
+{
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "  ";
+    return Json::writeString(builder, value);
+}
+
+void appendSection(
+    std::ostringstream& out, const char* name, const bcos::air::cli::InspectSection& section)
+{
+    if (!section.available && section.reason.empty() &&
+        (section.data.isNull() || section.data.empty()))
+    {
+        return;
+    }
+
+    out << name << ": " << (section.available ? "available" : "unavailable");
+    if (!section.reason.empty())
+    {
+        out << " (" << section.reason << ")";
+    }
+    if (!section.data.isNull() && !section.data.empty())
+    {
+        out << " data=" << writeJson(section.data);
+    }
+    out << "\n";
+}
+}  // namespace
+
+namespace bcos::air::cli
+{
+std::string renderHumanReadable(const InspectResponse& response)
+{
+    std::ostringstream out;
+    out << "Source: " << response.source << "\n";
+    out << "Command: " << response.command;
+    if (!response.domain.empty())
+    {
+        out << " " << response.domain;
+    }
+    out << "\n";
+    if (!response.timestamp.empty())
+    {
+        out << "Timestamp: " << response.timestamp << "\n";
+    }
+    out << "Summary: latestBlock=" << response.summary.latestBlock
+        << " totalTx=" << response.summary.totalTx << "\n";
+
+    for (const auto& warning : response.warnings)
+    {
+        out << "Warning: " << warning << "\n";
+    }
+
+    appendSection(out, "Node", response.node);
+    appendSection(out, "Chain", response.chain);
+    appendSection(out, "Network", response.network);
+    appendSection(out, "Storage", response.storage);
+    appendSection(out, "Executor", response.executor);
+    appendSection(out, "Logs", response.logs);
+    return out.str();
+}
+
+std::string renderJson(const InspectResponse& response)
+{
+    return writeJson(toJson(response));
+}
+
+std::string renderInspectResponse(const InspectResponse& response, bool jsonOutput)
+{
+    return jsonOutput ? renderJson(response) : renderHumanReadable(response);
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectRenderer.h
+++ b/fisco-bcos-air/cli/InspectRenderer.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "InspectTypes.h"
+#include <string>
+
+namespace bcos::air::cli
+{
+std::string renderHumanReadable(const InspectResponse& response);
+std::string renderJson(const InspectResponse& response);
+std::string renderInspectResponse(const InspectResponse& response, bool jsonOutput);
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectTypes.cpp
+++ b/fisco-bcos-air/cli/InspectTypes.cpp
@@ -1,0 +1,51 @@
+#include "InspectTypes.h"
+
+namespace bcos::air::cli
+{
+Json::Value toJson(const InspectSection& section)
+{
+    Json::Value value(Json::objectValue);
+    value["available"] = section.available;
+    if (!section.reason.empty())
+    {
+        value["reason"] = section.reason;
+    }
+    value["data"] = section.data;
+    return value;
+}
+
+Json::Value toJson(const InspectResponse& response)
+{
+    Json::Value value(Json::objectValue);
+    value["source"] = response.source;
+    value["command"] = response.command;
+    if (!response.domain.empty())
+    {
+        value["domain"] = response.domain;
+    }
+    if (!response.timestamp.empty())
+    {
+        value["timestamp"] = response.timestamp;
+    }
+
+    Json::Value summary(Json::objectValue);
+    summary["latestBlock"] = response.summary.latestBlock;
+    summary["totalTx"] = response.summary.totalTx;
+    value["summary"] = std::move(summary);
+
+    value["node"] = toJson(response.node);
+    value["chain"] = toJson(response.chain);
+    value["network"] = toJson(response.network);
+    value["storage"] = toJson(response.storage);
+    value["executor"] = toJson(response.executor);
+    value["logs"] = toJson(response.logs);
+
+    Json::Value warnings(Json::arrayValue);
+    for (const auto& warning : response.warnings)
+    {
+        warnings.append(warning);
+    }
+    value["warnings"] = std::move(warnings);
+    return value;
+}
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/cli/InspectTypes.h
+++ b/fisco-bcos-air/cli/InspectTypes.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <json/json.h>
+#include <string>
+#include <vector>
+
+namespace bcos::air::cli
+{
+struct InspectSection
+{
+    bool available = false;
+    std::string reason;
+    Json::Value data = Json::objectValue;
+};
+
+struct InspectSummary
+{
+    std::string latestBlock;
+    std::string totalTx;
+};
+
+struct InspectResponse
+{
+    std::string source;
+    std::string command;
+    std::string domain;
+    std::string timestamp;
+    InspectSection node;
+    InspectSection chain;
+    InspectSection network;
+    InspectSection storage;
+    InspectSection executor;
+    InspectSection logs;
+    InspectSummary summary;
+    std::vector<std::string> warnings;
+};
+
+Json::Value toJson(const InspectSection& section);
+Json::Value toJson(const InspectResponse& response);
+}  // namespace bcos::air::cli

--- a/fisco-bcos-air/main.cpp
+++ b/fisco-bcos-air/main.cpp
@@ -24,6 +24,7 @@
  */
 #include "AirNodeInitializer.h"
 #include "Common.h"
+#include "cli/InspectApplication.h"
 #include "libinitializer/CommandHelper.h"
 #include <bcos-crypto/signature/key/KeyFactoryImpl.h>
 #include <bcos-tool/NodeConfig.h>
@@ -33,17 +34,6 @@
 using namespace bcos::node;
 using namespace bcos::initializer;
 using namespace bcos::node;
-
-namespace
-{
-int runAirInspectCLI(const bcos::initializer::Params& param)
-{
-    std::cout << "[" << bcos::getCurrentDateTime() << "] ";
-    std::cout << "inspect cli command '" << param.cliRequest.command << "' is not implemented yet."
-              << std::endl;
-    return -1;
-}
-}  // namespace
 
 int main(int argc, const char* argv[])
 {
@@ -70,7 +60,7 @@ int main(int argc, const char* argv[])
         auto param = bcos::initializer::initAirNodeCommandLine(argc, argv, false);
         if (param.cliMode)
         {
-            return runAirInspectCLI(param);
+            return bcos::air::cli::runAirInspectCLI(param);
         }
         if (param.op != bcos::initializer::Params::operation::None)
         {

--- a/fisco-bcos-air/main.cpp
+++ b/fisco-bcos-air/main.cpp
@@ -34,6 +34,17 @@ using namespace bcos::node;
 using namespace bcos::initializer;
 using namespace bcos::node;
 
+namespace
+{
+int runAirInspectCLI(const bcos::initializer::Params& param)
+{
+    std::cout << "[" << bcos::getCurrentDateTime() << "] ";
+    std::cout << "inspect cli command '" << param.cliRequest.command << "' is not implemented yet."
+              << std::endl;
+    return -1;
+}
+}  // namespace
+
 int main(int argc, const char* argv[])
 {
     /// set LC_ALL
@@ -57,6 +68,10 @@ int main(int argc, const char* argv[])
     try
     {
         auto param = bcos::initializer::initAirNodeCommandLine(argc, argv, false);
+        if (param.cliMode)
+        {
+            return runAirInspectCLI(param);
+        }
         if (param.op != bcos::initializer::Params::operation::None)
         {
             if (param.hasOp(bcos::initializer::Params::operation::Prune))

--- a/libinitializer/CommandHelper.cpp
+++ b/libinitializer/CommandHelper.cpp
@@ -22,6 +22,8 @@
 #include <include/BuildInfo.h>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <stdexcept>
+#include <vector>
 
 void bcos::initializer::printVersion()
 {
@@ -72,8 +74,26 @@ void bcos::initializer::initCommandLine(int argc, char* argv[])
     }
 }
 
-bcos::initializer::Params bcos::initializer::initAirNodeCommandLine(
-    int argc, const char* argv[], bool _autoSendTx)
+namespace
+{
+std::vector<std::string> normalizeAirNodeArgs(int argc, const char* argv[])
+{
+    std::vector<std::string> normalizedArgs;
+    normalizedArgs.reserve(argc > 1 ? static_cast<size_t>(argc - 1) : 0U);
+    for (int i = 1; i < argc; ++i)
+    {
+        auto arg = std::string(argv[i]);
+        if (arg == "-cli")
+        {
+            normalizedArgs.emplace_back("--cli");
+            continue;
+        }
+        normalizedArgs.emplace_back(std::move(arg));
+    }
+    return normalizedArgs;
+}
+
+boost::program_options::options_description buildAirNodeOptions(bool autoSendTx)
 {
     boost::program_options::options_description main_options("Usage of FISCO-BCOS");
     main_options.add_options()("help,h", "print help information")(
@@ -86,69 +106,88 @@ bcos::initializer::Params bcos::initializer::initAirNodeCommandLine(
         "generate snapshot with or without txs and receipts, if true generate snapshot with txs "
         "and receipts")(
         "output,o", boost::program_options::value<std::string>(), "snapshot output directory")(
-        "import,i", boost::program_options::value<std::string>(), "import snapshot from directory");
+        "import,i", boost::program_options::value<std::string>(), "import snapshot from directory")(
+        "cli", "run inspect CLI mode")("json", "render inspect output as JSON")("verbose",
+        "show more inspect details")("source", "show selected inspect data source")("timeout",
+        boost::program_options::value<int>()->default_value(3000),
+        "inspect timeout in milliseconds")(
+        "tail", boost::program_options::value<int>(), "tail line count for inspect logs")(
+        "level", boost::program_options::value<std::string>(), "log level filter");
 
-    if (_autoSendTx)
+    if (autoSendTx)
     {
         main_options.add_options()(
             "txSpeed,t", boost::program_options::value<float>(), "transaction generate speed");
     }
+
+    return main_options;
+}
+
+void fillCLIRequest(const boost::program_options::variables_map& vm,
+    const std::vector<std::string>& positional, bcos::initializer::CLIRequest& request)
+{
+    if (positional.empty())
+    {
+        throw std::runtime_error("cli command is required");
+    }
+
+    request.command = positional.at(0);
+    if (request.command != "inspect")
+    {
+        throw std::runtime_error("unsupported cli command: " + request.command);
+    }
+
+    if (positional.size() > 1)
+    {
+        request.domain = positional.at(1);
+    }
+    if (positional.size() > 2)
+    {
+        throw std::runtime_error("too many cli positional arguments");
+    }
+
+    request.jsonOutput = vm.count("json");
+    request.verbose = vm.count("verbose");
+    request.showSource = vm.count("source");
+    request.timeoutMs = vm["timeout"].as<int>();
+    if (vm.count("tail"))
+    {
+        request.tail = vm["tail"].as<int>();
+    }
+    if (vm.count("level"))
+    {
+        request.logLevel = vm["level"].as<std::string>();
+    }
+}
+}  // namespace
+
+bcos::initializer::Params bcos::initializer::parseAirNodeCommandLine(
+    int argc, const char* argv[], bool _autoSendTx)
+{
+    auto normalizedArgs = normalizeAirNodeArgs(argc, argv);
+    auto main_options = buildAirNodeOptions(_autoSendTx);
     boost::program_options::variables_map vm;
-    try
-    {
-        boost::program_options::store(
-            boost::program_options::parse_command_line(argc, argv, main_options), vm);
-    }
-    catch (...)
-    {
-        std::cout << "invalid parameters" << std::endl;
-        std::cout << main_options << std::endl;
-        exit(0);
-    }
-    /// help information
-    if (vm.count("help") || vm.count("h"))
-    {
-        std::cout << main_options << std::endl;
-        exit(0);
-    }
-    /// version information
-    if (vm.count("version") || vm.count("v"))
-    {
-        bcos::initializer::printVersion();
-        exit(0);
-    }
-    std::string configPath("./config.ini");
-    if (vm.count("config"))
-    {
-        configPath = vm["config"].as<std::string>();
-    }
-    if (vm.count("c"))
-    {
-        configPath = vm["c"].as<std::string>();
-    }
-    std::string genesisFilePath("./config.genesis");
-    if (vm.count("genesis"))
-    {
-        genesisFilePath = vm["genesis"].as<std::string>();
-    }
-    if (vm.count("g"))
-    {
-        genesisFilePath = vm["g"].as<std::string>();
-    }
+    auto parsed = boost::program_options::command_line_parser(normalizedArgs)
+                      .options(main_options)
+                      .allow_unregistered()
+                      .run();
+    boost::program_options::store(parsed, vm);
+    boost::program_options::notify(vm);
+
+    auto configPath = vm["config"].as<std::string>();
+    auto genesisFilePath = vm["genesis"].as<std::string>();
     if (!boost::filesystem::exists(configPath))
     {
-        std::cout << "config \'" << configPath << "\' not found!";
-        exit(0);
+        throw std::runtime_error("config '" + configPath + "' not found!");
     }
     if (!boost::filesystem::exists(genesisFilePath))
     {
-        std::cout << "genesis config \'" << genesisFilePath << "\' not found!";
-        exit(0);
+        throw std::runtime_error("genesis config '" + genesisFilePath + "' not found!");
     }
-    float txSpeed = 10;
+    float txSpeed = 10.0f;
     if (_autoSendTx)
     {
-        if (vm.count("txSpeed") || vm.count("t"))
+        if (vm.count("txSpeed"))
         {
             txSpeed = vm["txSpeed"].as<float>();
         }
@@ -190,5 +229,58 @@ bcos::initializer::Params bcos::initializer::initAirNodeCommandLine(
         snapshotPath = vm["import"].as<std::string>();
     }
 
-    return bcos::initializer::Params{configPath, genesisFilePath, snapshotPath, txSpeed, op};
+    Params params;
+    params.configFilePath = configPath;
+    params.genesisFilePath = genesisFilePath;
+    params.snapshotPath = snapshotPath;
+    params.txSpeed = txSpeed;
+    params.op = op;
+    params.cliMode = vm.count("cli");
+    if (params.cliMode)
+    {
+        auto positional = boost::program_options::collect_unrecognized(
+            parsed.options, boost::program_options::include_positional);
+        fillCLIRequest(vm, positional, params.cliRequest);
+    }
+    return params;
+}
+
+bcos::initializer::Params bcos::initializer::initAirNodeCommandLine(
+    int argc, const char* argv[], bool _autoSendTx)
+{
+    auto normalizedArgs = normalizeAirNodeArgs(argc, argv);
+    auto main_options = buildAirNodeOptions(_autoSendTx);
+    try
+    {
+        boost::program_options::variables_map vm;
+        auto parsed = boost::program_options::command_line_parser(normalizedArgs)
+                          .options(main_options)
+                          .allow_unregistered()
+                          .run();
+        boost::program_options::store(parsed, vm);
+        if (vm.count("help") || vm.count("h"))
+        {
+            std::cout << main_options << std::endl;
+            exit(0);
+        }
+        if (vm.count("version") || vm.count("v"))
+        {
+            bcos::initializer::printVersion();
+            exit(0);
+        }
+        auto params = parseAirNodeCommandLine(argc, argv, _autoSendTx);
+        if (params.cliMode && params.op != Params::operation::None)
+        {
+            std::cout << "cli mode can not be used with other operations" << std::endl;
+            std::cout << main_options << std::endl;
+            exit(0);
+        }
+        return params;
+    }
+    catch (std::exception const& e)
+    {
+        std::cout << "invalid parameters: " << e.what() << std::endl;
+        std::cout << main_options << std::endl;
+        exit(0);
+    }
 }

--- a/libinitializer/CommandHelper.h
+++ b/libinitializer/CommandHelper.h
@@ -20,6 +20,7 @@
 #pragma once
 #include <iostream>
 #include <memory>
+#include <optional>
 namespace bcos
 {
 namespace initializer
@@ -28,12 +29,26 @@ void printVersion();
 void showNodeVersionMetric();
 void initCommandLine(int argc, char* argv[]);
 
+struct CLIRequest
+{
+    std::string command;
+    std::string domain;
+    bool jsonOutput = false;
+    bool verbose = false;
+    bool showSource = false;
+    int timeoutMs = 3000;
+    std::optional<int> tail;
+    std::string logLevel;
+};
+
 struct Params
 {
     std::string configFilePath;
     std::string genesisFilePath;
     std::string snapshotPath;  // import from or export to
-    float txSpeed;
+    float txSpeed = 10;
+    bool cliMode = false;
+    CLIRequest cliRequest;
     enum class operation : int
     {
         None = 0,
@@ -58,6 +73,7 @@ inline Params::operation operator&(Params::operation left, Params::operation rig
     return static_cast<Params::operation>(static_cast<int>(left) & static_cast<int>(right));
 }
 
+Params parseAirNodeCommandLine(int argc, const char* argv[], bool _autoSendTx);
 Params initAirNodeCommandLine(int argc, const char* argv[], bool _autoSendTx);
 }  // namespace initializer
 }  // namespace bcos

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(TBB CONFIG REQUIRED)
 
 add_executable(fisco-bcos-test ${SOURCES})
 find_package(Boost REQUIRED unit_test_framework program_options)
-target_link_libraries(fisco-bcos-test PUBLIC ${TOOL_TARGET} ${CRYPTO_TARGET} ${TARS_PROTOCOL_TARGET} Boost::program_options Boost::unit_test_framework TBB::tbb)
+target_link_libraries(fisco-bcos-test PUBLIC ${TOOL_TARGET} ${CRYPTO_TARGET} ${TARS_PROTOCOL_TARGET}
+    ${COMMAND_HELPER_LIB} Boost::program_options Boost::unit_test_framework TBB::tbb)
 
 # add_test(NAME fisco-bcos-test WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND fisco-bcos-test)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(TBB CONFIG REQUIRED)
 add_executable(fisco-bcos-test ${SOURCES})
 find_package(Boost REQUIRED unit_test_framework program_options)
 target_link_libraries(fisco-bcos-test PUBLIC ${TOOL_TARGET} ${CRYPTO_TARGET} ${TARS_PROTOCOL_TARGET}
-    ${COMMAND_HELPER_LIB} Boost::program_options Boost::unit_test_framework TBB::tbb)
+    ${COMMAND_HELPER_LIB} air-cli Boost::program_options Boost::unit_test_framework TBB::tbb)
 
 # add_test(NAME fisco-bcos-test WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND fisco-bcos-test)
 

--- a/tests/unittest/AirInspectCLITest.cpp
+++ b/tests/unittest/AirInspectCLITest.cpp
@@ -1,3 +1,5 @@
+#include "fisco-bcos-air/cli/AdminIPCClient.h"
+#include "fisco-bcos-air/cli/AdminIPCServer.h"
 #include "fisco-bcos-air/cli/FallbackInspectors.h"
 #include "fisco-bcos-air/cli/InspectApplication.h"
 #include "fisco-bcos-air/cli/InspectConfig.h"
@@ -137,4 +139,31 @@ BOOST_AUTO_TEST_CASE(fallbackResponseReportsRpcAndLogsSourceEvenWhenAdminEnabled
 
     auto response = bcos::air::cli::InspectApplication::buildResponse(request, config);
     BOOST_CHECK_EQUAL(response.source, "rpc+logs");
+}
+
+BOOST_AUTO_TEST_CASE(reachabilityProbeDoesNotBreakAdminIpcServer)
+{
+    TempInspectConfigFile file;
+    bcos::air::cli::InspectConfig config;
+    config.adminEnabled = true;
+    config.adminIPCPath = (file.directory / "run/admin.sock").string();
+
+    bcos::air::cli::AdminIPCServer server;
+    server.start(config, [](const auto& request) {
+        bcos::air::cli::AdminInspectReply reply;
+        reply.ok = (request.command == "inspect");
+        reply.payload["source"] = "admin-ipc";
+        return reply;
+    });
+
+    bcos::air::cli::AdminIPCClient client;
+    BOOST_CHECK(client.reachable(config.adminIPCPath));
+
+    bcos::air::cli::AdminInspectRequest request;
+    request.command = "inspect";
+    auto reply = client.request(config.adminIPCPath, request);
+    BOOST_CHECK(reply.ok);
+    BOOST_CHECK_EQUAL(reply.payload["source"].asString(), "admin-ipc");
+
+    server.stop();
 }

--- a/tests/unittest/AirInspectCLITest.cpp
+++ b/tests/unittest/AirInspectCLITest.cpp
@@ -1,4 +1,5 @@
 #include "fisco-bcos-air/cli/FallbackInspectors.h"
+#include "fisco-bcos-air/cli/InspectApplication.h"
 #include "fisco-bcos-air/cli/InspectConfig.h"
 #include "fisco-bcos-air/cli/InspectRenderer.h"
 #include "fisco-bcos-air/cli/InspectTypes.h"
@@ -72,7 +73,8 @@ ipc_path=./run/admin.sock
     BOOST_CHECK_EQUAL(config.preferredSource(), "rpc+logs");
     BOOST_CHECK_EQUAL(config.rpcListenIP, "127.0.0.1");
     BOOST_CHECK_EQUAL(config.rpcListenPort, 20200);
-    BOOST_CHECK_EQUAL(config.logPath, "./log");
+    BOOST_CHECK_EQUAL(config.logPath, (file.directory / "log").string());
+    BOOST_CHECK_EQUAL(config.adminIPCPath, (file.directory / "run/admin.sock").string());
 }
 
 BOOST_AUTO_TEST_CASE(logInspectorReadsConfiguredPath)
@@ -101,4 +103,38 @@ BOOST_AUTO_TEST_CASE(executorSectionIsMarkedUnavailableInFallbackMode)
     BOOST_CHECK(!section.available);
     BOOST_CHECK(section.reason.find("rpc+logs") != std::string::npos);
     BOOST_CHECK_EQUAL(section.data["source"].asString(), "rpc+logs");
+}
+
+BOOST_AUTO_TEST_CASE(selectsAdminIpcWhenEnabledAndReachable)
+{
+    bcos::air::cli::InspectConfig config;
+    config.adminEnabled = true;
+    config.adminIPCPath = "/tmp/fisco-bcos-admin.sock";
+
+    bcos::air::cli::InspectApplication app(config);
+    app.setAdminReachabilityForTest(true);
+    BOOST_CHECK_EQUAL(app.selectSource(), "admin-ipc");
+}
+
+BOOST_AUTO_TEST_CASE(fallsBackWhenAdminIpcUnavailable)
+{
+    bcos::air::cli::InspectConfig config;
+    config.adminEnabled = true;
+    config.adminIPCPath = "/tmp/missing.sock";
+
+    bcos::air::cli::InspectApplication app(config);
+    app.setAdminReachabilityForTest(false);
+    BOOST_CHECK_EQUAL(app.selectSource(), "rpc+logs");
+}
+
+BOOST_AUTO_TEST_CASE(fallbackResponseReportsRpcAndLogsSourceEvenWhenAdminEnabled)
+{
+    bcos::initializer::CLIRequest request;
+    request.command = "inspect";
+
+    bcos::air::cli::InspectConfig config;
+    config.adminEnabled = true;
+
+    auto response = bcos::air::cli::InspectApplication::buildResponse(request, config);
+    BOOST_CHECK_EQUAL(response.source, "rpc+logs");
 }

--- a/tests/unittest/AirInspectCLITest.cpp
+++ b/tests/unittest/AirInspectCLITest.cpp
@@ -1,0 +1,104 @@
+#include "fisco-bcos-air/cli/FallbackInspectors.h"
+#include "fisco-bcos-air/cli/InspectConfig.h"
+#include "fisco-bcos-air/cli/InspectRenderer.h"
+#include "fisco-bcos-air/cli/InspectTypes.h"
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fstream>
+#include <optional>
+
+namespace
+{
+struct TempInspectConfigFile
+{
+    TempInspectConfigFile()
+    {
+        directory = boost::filesystem::temp_directory_path() /
+                    boost::filesystem::unique_path("air-inspect-config-%%%%-%%%%-%%%%");
+        boost::filesystem::create_directories(directory);
+        path = (directory / "config.ini").string();
+    }
+
+    ~TempInspectConfigFile() { boost::filesystem::remove_all(directory); }
+
+    void write(const std::string& content)
+    {
+        std::ofstream out(path);
+        out << content;
+        out.close();
+    }
+
+    boost::filesystem::path directory;
+    std::string path;
+};
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(renderHumanReadableOverview)
+{
+    bcos::air::cli::InspectResponse response;
+    response.source = "rpc+logs";
+    response.command = "inspect";
+    response.summary.latestBlock = "123";
+    response.summary.totalTx = "456";
+
+    auto rendered = bcos::air::cli::renderHumanReadable(response);
+    BOOST_CHECK(rendered.find("Source: rpc+logs") != std::string::npos);
+    BOOST_CHECK(rendered.find("latestBlock=123") != std::string::npos);
+    BOOST_CHECK(rendered.find("totalTx=456") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(selectsRpcAndLogsWhenAdminDisabled)
+{
+    TempInspectConfigFile file;
+    file.write(R"([rpc]
+listen_ip=127.0.0.1
+listen_port=20200
+
+[web3_rpc]
+enable=false
+listen_ip=127.0.0.1
+listen_port=8545
+
+[log]
+log_path=./log
+
+[admin]
+enable=false
+ipc_path=./run/admin.sock
+)");
+
+    auto config = bcos::air::cli::loadInspectConfig(file.path);
+    BOOST_CHECK(!config.adminEnabled);
+    BOOST_CHECK_EQUAL(config.preferredSource(), "rpc+logs");
+    BOOST_CHECK_EQUAL(config.rpcListenIP, "127.0.0.1");
+    BOOST_CHECK_EQUAL(config.rpcListenPort, 20200);
+    BOOST_CHECK_EQUAL(config.logPath, "./log");
+}
+
+BOOST_AUTO_TEST_CASE(logInspectorReadsConfiguredPath)
+{
+    TempInspectConfigFile file;
+    auto logDir = file.directory / "log";
+    boost::filesystem::create_directories(logDir);
+    std::ofstream((logDir / "node.log").string()) << "[INFO] node started\n"
+                                                  << "[DEBUG] trace detail\n"
+                                                  << "[INFO] block sealed\n";
+
+    bcos::air::cli::InspectConfig config;
+    config.logPath = logDir.string();
+
+    auto section = bcos::air::cli::buildFallbackLogSection(config, 2, "INFO");
+    BOOST_CHECK(section.available);
+    BOOST_CHECK(section.data.isObject());
+    BOOST_CHECK_EQUAL(section.data["path"].asString(), logDir.string());
+    BOOST_CHECK(section.data["entries"].isArray());
+    BOOST_CHECK_EQUAL(section.data["entries"].size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(executorSectionIsMarkedUnavailableInFallbackMode)
+{
+    auto section = bcos::air::cli::buildUnavailableExecutorFallbackSection();
+    BOOST_CHECK(!section.available);
+    BOOST_CHECK(section.reason.find("rpc+logs") != std::string::npos);
+    BOOST_CHECK_EQUAL(section.data["source"].asString(), "rpc+logs");
+}

--- a/tests/unittest/CommandHelperTest.cpp
+++ b/tests/unittest/CommandHelperTest.cpp
@@ -1,0 +1,57 @@
+#include "libinitializer/CommandHelper.h"
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fstream>
+
+using namespace bcos::initializer;
+
+namespace
+{
+struct TempConfigFiles
+{
+    TempConfigFiles()
+    {
+        directory = boost::filesystem::temp_directory_path() /
+                    boost::filesystem::unique_path("air-cli-inspect-%%%%-%%%%-%%%%");
+        boost::filesystem::create_directories(directory);
+        configPath = (directory / "config.ini").string();
+        genesisPath = (directory / "config.genesis").string();
+        std::ofstream(configPath).close();
+        std::ofstream(genesisPath).close();
+    }
+
+    ~TempConfigFiles() { boost::filesystem::remove_all(directory); }
+
+    boost::filesystem::path directory;
+    std::string configPath;
+    std::string genesisPath;
+};
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(parseInspectOverviewCli)
+{
+    TempConfigFiles files;
+    const char* argv[] = {"fisco-bcos", "-c", files.configPath.c_str(), "-g",
+        files.genesisPath.c_str(), "-cli", "inspect"};
+    auto params = parseAirNodeCommandLine(static_cast<int>(std::size(argv)), argv, false);
+
+    BOOST_CHECK(params.cliMode);
+    BOOST_CHECK_EQUAL(params.cliRequest.command, "inspect");
+    BOOST_CHECK_EQUAL(params.cliRequest.domain, "");
+    BOOST_CHECK(!params.cliRequest.jsonOutput);
+    BOOST_CHECK_EQUAL(params.configFilePath, files.configPath);
+}
+
+BOOST_AUTO_TEST_CASE(parseInspectDomainJsonCli)
+{
+    TempConfigFiles files;
+    const char* argv[] = {"fisco-bcos", "-c", files.configPath.c_str(), "-g",
+        files.genesisPath.c_str(), "-cli", "inspect", "network", "--json", "--timeout", "2500"};
+    auto params = parseAirNodeCommandLine(static_cast<int>(std::size(argv)), argv, false);
+
+    BOOST_CHECK(params.cliMode);
+    BOOST_CHECK_EQUAL(params.cliRequest.command, "inspect");
+    BOOST_CHECK_EQUAL(params.cliRequest.domain, "network");
+    BOOST_CHECK(params.cliRequest.jsonOutput);
+    BOOST_CHECK_EQUAL(params.cliRequest.timeoutMs, 2500);
+}

--- a/tools/.ci/ci_air_cli_inspect_integration.sh
+++ b/tools/.ci/ci_air_cli_inspect_integration.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DEFAULT_BINARY="${REPO_ROOT}/build-make/fisco-bcos-air/fisco-bcos"
+FISCO_BCOS_BINARY="${FISCO_BCOS_BINARY:-${1:-${DEFAULT_BINARY}}}"
+BUILD_CHAIN="${REPO_ROOT}/tools/BcosAirBuilder/build_chain.sh"
+
+TMP_ROOT=""
+NODE_ROOT=""
+NODE_DIR=""
+
+LOG_INFO() {
+    local content="${1}"
+    echo -e "\033[32m[INFO] ${content}\033[0m"
+}
+
+LOG_ERROR() {
+    local content="${1}"
+    echo -e "\033[31m[ERROR] ${content}\033[0m"
+}
+
+cleanup() {
+    local exit_code=$?
+
+    if [[ -n "${NODE_DIR}" && -f "${NODE_DIR}/stop.sh" ]]; then
+        bash "${NODE_DIR}/stop.sh" >/dev/null 2>&1 || true
+    fi
+
+    if [[ -n "${TMP_ROOT}" && -d "${TMP_ROOT}" ]]; then
+        rm -rf "${TMP_ROOT}"
+    fi
+
+    exit "${exit_code}"
+}
+
+trap cleanup EXIT
+
+assert_file_exists() {
+    local path="${1}"
+    if [[ ! -f "${path}" ]]; then
+        LOG_ERROR "File not found: ${path}"
+        exit 1
+    fi
+}
+
+assert_binary() {
+    if [[ ! -x "${FISCO_BCOS_BINARY}" ]]; then
+        LOG_ERROR "fisco-bcos binary is not executable: ${FISCO_BCOS_BINARY}"
+        exit 1
+    fi
+    assert_file_exists "${BUILD_CHAIN}"
+}
+
+prepare_chain() {
+    TMP_ROOT="$(mktemp -d /tmp/fisco-air-cli-it.XXXXXX)"
+    NODE_ROOT="${TMP_ROOT}/nodes/127.0.0.1"
+    NODE_DIR="${NODE_ROOT}/node0"
+
+    LOG_INFO "Generate temporary air chain under ${TMP_ROOT}"
+    bash "${BUILD_CHAIN}" -p 43300,33200 -l 127.0.0.1:1 -o "${TMP_ROOT}/nodes" \
+        -e "${FISCO_BCOS_BINARY}" >/tmp/ci_air_cli_inspect_build.log 2>&1
+
+    assert_file_exists "${NODE_DIR}/config.ini"
+    assert_file_exists "${NODE_DIR}/config.genesis"
+
+    cat <<'EOF' >>"${NODE_DIR}/config.ini"
+
+[admin]
+enable=true
+ipc_path=./run/admin.sock
+EOF
+}
+
+start_node() {
+    LOG_INFO "Start node for admin-ipc integration test"
+    bash "${NODE_DIR}/start.sh"
+
+    local socket_path="${NODE_DIR}/run/admin.sock"
+    local ready="false"
+    for _ in $(seq 1 30); do
+        if [[ -S "${socket_path}" ]]; then
+            ready="true"
+            break
+        fi
+        sleep 1
+    done
+
+    if [[ "${ready}" != "true" ]]; then
+        LOG_ERROR "Admin IPC socket was not created: ${socket_path}"
+        tail -n 100 "${NODE_DIR}/nohup.out" || true
+        exit 1
+    fi
+}
+
+collect_fixtures() {
+    LOG_INFO "Collect inspect and RPC fixtures"
+
+    (
+        cd "${NODE_DIR}"
+        ../fisco-bcos -c config.ini -g config.genesis -cli inspect --json \
+            > inspect-overview.json
+    )
+
+    curl -sk \
+        --cert "${NODE_ROOT}/sdk/sdk.crt" \
+        --key "${NODE_ROOT}/sdk/sdk.key" \
+        --cacert "${NODE_ROOT}/sdk/ca.crt" \
+        https://127.0.0.1:33200 \
+        -X POST \
+        --data '{"jsonrpc":"2.0","method":"getBlockNumber","params":["group0", ""],"id":67}' \
+        >"${NODE_DIR}/rpc-getBlockNumber.json"
+
+    curl -sk \
+        --cert "${NODE_ROOT}/sdk/sdk.crt" \
+        --key "${NODE_ROOT}/sdk/sdk.key" \
+        --cacert "${NODE_ROOT}/sdk/ca.crt" \
+        https://127.0.0.1:33200 \
+        -X POST \
+        --data '{"jsonrpc":"2.0","method":"getTotalTransactionCount","params":["group0", ""],"id":68}' \
+        >"${NODE_DIR}/rpc-getTotalTransactionCount.json"
+}
+
+verify_results() {
+    LOG_INFO "Verify admin-ipc payload against config and RPC"
+
+    python3 - <<'PY' "${NODE_DIR}"
+import configparser
+import json
+import sys
+from pathlib import Path
+
+node_dir = Path(sys.argv[1])
+inspect = json.loads((node_dir / "inspect-overview.json").read_text())
+rpc_block = json.loads((node_dir / "rpc-getBlockNumber.json").read_text())
+rpc_total = json.loads((node_dir / "rpc-getTotalTransactionCount.json").read_text())
+
+ini = configparser.ConfigParser()
+ini.read(node_dir / "config.ini")
+genesis = configparser.ConfigParser()
+genesis.read(node_dir / "config.genesis")
+
+checks = []
+checks.append(("source", inspect["source"], "admin-ipc"))
+checks.append(("warnings", inspect["warnings"], []))
+checks.append(("summary.latestBlock", inspect["summary"]["latestBlock"], str(rpc_block["result"])))
+checks.append((
+    "summary.totalTx",
+    inspect["summary"]["totalTx"],
+    str(rpc_total["result"]["transactionCount"]),
+))
+checks.append(("chain.available", inspect["chain"]["available"], True))
+checks.append(("chain.chainID", inspect["chain"]["data"]["chainID"], genesis["chain"]["chain_id"]))
+checks.append(("chain.groupID", inspect["chain"]["data"]["groupID"], genesis["chain"]["group_id"]))
+checks.append((
+    "chain.consensusType",
+    inspect["chain"]["data"]["consensusType"],
+    genesis["consensus"]["consensus_type"],
+))
+checks.append((
+    "chain.latestBlock",
+    inspect["chain"]["data"]["latestBlock"],
+    rpc_total["result"]["blockNumber"],
+))
+checks.append((
+    "chain.totalTx",
+    inspect["chain"]["data"]["totalTx"],
+    rpc_total["result"]["transactionCount"],
+))
+checks.append((
+    "chain.failedTx",
+    inspect["chain"]["data"]["failedTx"],
+    rpc_total["result"]["failedTransactionCount"],
+))
+checks.append(("node.available", inspect["node"]["available"], True))
+checks.append(("node.chainID", inspect["node"]["data"]["chainID"], genesis["chain"]["chain_id"]))
+checks.append(("node.groupID", inspect["node"]["data"]["groupID"], genesis["chain"]["group_id"]))
+checks.append((
+    "node.nodeID",
+    inspect["node"]["data"]["nodeID"],
+    genesis["consensus"]["node.0"].split(":")[0].strip(),
+))
+checks.append((
+    "node.compatibilityVersion",
+    inspect["node"]["data"]["compatibilityVersion"],
+    genesis["version"]["compatibility_version"],
+))
+checks.append(("network.available", inspect["network"]["available"], True))
+checks.append((
+    "network.rpcListenIP",
+    inspect["network"]["data"]["rpcListenIP"],
+    ini["rpc"]["listen_ip"],
+))
+checks.append((
+    "network.rpcListenPort",
+    inspect["network"]["data"]["rpcListenPort"],
+    int(ini["rpc"]["listen_port"]),
+))
+checks.append((
+    "network.p2pListenIP",
+    inspect["network"]["data"]["p2pListenIP"],
+    ini["p2p"]["listen_ip"],
+))
+checks.append((
+    "network.p2pListenPort",
+    inspect["network"]["data"]["p2pListenPort"],
+    int(ini["p2p"]["listen_port"]),
+))
+checks.append((
+    "network.web3Enabled",
+    inspect["network"]["data"]["web3Enabled"],
+    ini["web3_rpc"].getboolean("enable"),
+))
+checks.append(("network.connectedNodeCount", inspect["network"]["data"]["connectedNodeCount"], 1))
+checks.append(("storage.available", inspect["storage"]["available"], True))
+checks.append(("storage.type", inspect["storage"]["data"]["type"], "RocksDB"))
+checks.append(("storage.dataPath", inspect["storage"]["data"]["dataPath"], ini["storage"]["data_path"]))
+checks.append((
+    "storage.stateDBPath",
+    inspect["storage"]["data"]["stateDBPath"],
+    ini["storage"]["data_path"] + "/state",
+))
+checks.append((
+    "storage.blockDBPath",
+    inspect["storage"]["data"]["blockDBPath"],
+    ini["storage"]["data_path"] + "/block",
+))
+checks.append(("executor.available", inspect["executor"]["available"], True))
+checks.append((
+    "executor.serialExecute",
+    inspect["executor"]["data"]["serialExecute"],
+    genesis["executor"].getboolean("is_serial_execute"),
+))
+checks.append(("logs.available", inspect["logs"]["available"], True))
+checks.append((
+    "logs.path",
+    str(Path(inspect["logs"]["data"]["path"]).as_posix()),
+    str(Path(ini["log"]["log_path"]).as_posix()),
+))
+checks.append(("logs.entryCountPositive", len(inspect["logs"]["data"]["entries"]) > 0, True))
+
+failed = [(name, actual, expected) for name, actual, expected in checks if actual != expected]
+
+for name, actual, expected in checks:
+    print(f"{name}: actual={actual!r} expected={expected!r}")
+
+if failed:
+    print("FAILED_ITEMS:")
+    for name, actual, expected in failed:
+        print(f"  {name}: actual={actual!r} expected={expected!r}")
+    raise SystemExit(1)
+
+print("ALL_CHECKS_PASSED")
+PY
+}
+
+main() {
+    assert_binary
+    prepare_chain
+    start_node
+    collect_fixtures
+    verify_results
+    LOG_INFO "air cli inspect admin-ipc integration test passed"
+}
+
+main "$@"

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
@@ -78,12 +78,6 @@ bcos::executor_v1::hostcontext::getCacheExecutables()
     return cachedExecutables.m_cachedExecutables;
 }
 
-std::mutex& bcos::executor_v1::hostcontext::getCacheMutex()
-{
-    static std::mutex g_cacheMutex;
-    return g_cacheMutex;
-}
-
 bcos::executor_v1::hostcontext::Executable::Executable(storage::Entry code, evmc_revision revision)
   : m_code(std::make_optional(std::move(code))),
     m_vmInstance(VMFactory::create(VMKind::evmone,

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
@@ -78,6 +78,12 @@ bcos::executor_v1::hostcontext::getCacheExecutables()
     return cachedExecutables.m_cachedExecutables;
 }
 
+std::mutex& bcos::executor_v1::hostcontext::getCacheMutex()
+{
+    static std::mutex g_cacheMutex;
+    return g_cacheMutex;
+}
+
 bcos::executor_v1::hostcontext::Executable::Executable(storage::Entry code, evmc_revision revision)
   : m_code(std::make_optional(std::move(code))),
     m_vmInstance(VMFactory::create(VMKind::evmone,

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -59,7 +59,6 @@
 #include <intx/intx.hpp>
 #include <iterator>
 #include <memory>
-#include <mutex>
 #include <string_view>
 
 namespace bcos::executor_v1::hostcontext
@@ -96,32 +95,18 @@ using CacheExecutables =
         std::hash<evmc_address>>;
 CacheExecutables& getCacheExecutables();
 
-// FIB-114: Mutex to protect cache operations from concurrent access
-inline std::mutex& getCacheMutex();
-
 task::Task<std::shared_ptr<Executable>> getExecutable(
     auto& storage, const evmc_address& address, const evmc_revision& revision, bool binaryAddress)
 {
-    // First try to read from cache (cache hit path - no locking needed)
     if (auto executable = co_await storage2::readOne(getCacheExecutables(), address))
     {
         co_return std::move(*executable);
     }
 
-    // Cache miss - load code from storage
     if (Account<std::decay_t<decltype(storage)>> account(storage, address, binaryAddress);
         auto codeEntry = co_await account.code())
     {
         auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
-
-        // Acquire lock only for cache write - note: this introduces a brief window where
-        // concurrent cache misses could create duplicate entries, but this is acceptable
-        // as MemoryStorage with CONCURRENT handles concurrent writes safely
-        // The lock ensures we don't have uncontrolled concurrent cache modifications
-        std::lock_guard<std::mutex> lock(getCacheMutex());
-        // NOLINTNEXTLINE(cppcoreguidelines-no-suspend-with-lock)
-        // The write operation is synchronous in practice (in-memory storage) and any
-        // suspension is extremely brief, so holding the lock is safe in this context
         co_await storage2::writeOne(getCacheExecutables(), address, executable);
         co_return executable;
     }

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -59,6 +59,7 @@
 #include <intx/intx.hpp>
 #include <iterator>
 #include <memory>
+#include <mutex>
 #include <string_view>
 
 namespace bcos::executor_v1::hostcontext
@@ -95,18 +96,32 @@ using CacheExecutables =
         std::hash<evmc_address>>;
 CacheExecutables& getCacheExecutables();
 
+// FIB-114: Mutex to protect cache operations from concurrent access
+inline std::mutex& getCacheMutex();
+
 task::Task<std::shared_ptr<Executable>> getExecutable(
     auto& storage, const evmc_address& address, const evmc_revision& revision, bool binaryAddress)
 {
+    // First try to read from cache (cache hit path - no locking needed)
     if (auto executable = co_await storage2::readOne(getCacheExecutables(), address))
     {
         co_return std::move(*executable);
     }
 
+    // Cache miss - load code from storage
     if (Account<std::decay_t<decltype(storage)>> account(storage, address, binaryAddress);
         auto codeEntry = co_await account.code())
     {
         auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
+
+        // Acquire lock only for cache write - note: this introduces a brief window where
+        // concurrent cache misses could create duplicate entries, but this is acceptable
+        // as MemoryStorage with CONCURRENT handles concurrent writes safely
+        // The lock ensures we don't have uncontrolled concurrent cache modifications
+        std::lock_guard<std::mutex> lock(getCacheMutex());
+        // NOLINTNEXTLINE(cppcoreguidelines-no-suspend-with-lock)
+        // The write operation is synchronous in practice (in-memory storage) and any
+        // suspension is extremely brief, so holding the lock is safe in this context
         co_await storage2::writeOne(getCacheExecutables(), address, executable);
         co_return executable;
     }


### PR DESCRIPTION
## Summary
- add opt-in local admin IPC transport for `./fisco-bcos -cli inspect`
- serve real in-process node, chain, network, storage, executor and log views when IPC is enabled
- fall back to `rpc+logs` when admin IPC is disabled or unreachable, and resolve relative inspect paths from the config directory

## Verification
- `cmake --build build-make --target fisco-bcos-test fisco-bcos -j4`
- `./build-make/tests/fisco-bcos-test --run_test=selectsRpcAndLogsWhenAdminDisabled,logInspectorReadsConfiguredPath,selectsAdminIpcWhenEnabledAndReachable,fallsBackWhenAdminIpcUnavailable,fallbackResponseReportsRpcAndLogsSourceEvenWhenAdminEnabled --log_level=test_suite`
- run `./build-make/fisco-bcos-air/fisco-bcos -c <tmp>/config.ini -g tools/BcosBuilder/src/tpl/config.genesis -cli inspect logs --json --tail 2 --level INFO` against a temp local log dir and confirm `source=rpc+logs` with filtered entries
