### PR TITLE
feat(mpt): add TrieNode variant + NodeEncoder (M2.2)

### DIFF
--- a/bcos-ledger/CMakeLists.txt
+++ b/bcos-ledger/CMakeLists.txt
@@ -19,7 +19,13 @@
 
 find_package(Boost REQUIRED serialization)
 
-add_library(ledger bcos-ledger/Ledger.cpp bcos-ledger/LedgerMethods.cpp bcos-ledger/ConsensusNode.cpp)
+add_library(ledger
+    bcos-ledger/Ledger.cpp
+    bcos-ledger/LedgerMethods.cpp
+    bcos-ledger/ConsensusNode.cpp
+    bcos-ledger/mpt/Nibble.cpp
+    bcos-ledger/mpt/HexPrefix.cpp
+    bcos-ledger/mpt/Constants.cpp)
 target_include_directories(ledger PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-ledger>)

--- a/bcos-ledger/CMakeLists.txt
+++ b/bcos-ledger/CMakeLists.txt
@@ -25,11 +25,12 @@ add_library(ledger
     bcos-ledger/ConsensusNode.cpp
     bcos-ledger/mpt/Nibble.cpp
     bcos-ledger/mpt/HexPrefix.cpp
-    bcos-ledger/mpt/Constants.cpp)
+    bcos-ledger/mpt/Constants.cpp
+    bcos-ledger/mpt/NodeEncoder.cpp)
 target_include_directories(ledger PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-ledger>)
-target_link_libraries(ledger PUBLIC tool protocol-tars codec table bcos-concepts Boost::serialization)
+target_link_libraries(ledger PUBLIC tool protocol-tars codec table bcos-concepts bcos-crypto Boost::serialization)
 set_target_properties(ledger PROPERTIES UNITY_BUILD "ON")
 
 # test related

--- a/bcos-ledger/bcos-ledger/mpt/Constants.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Constants.cpp
@@ -1,0 +1,38 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Constants.cpp
+ * @brief Definitions of Ethereum well-known hash constants (Meyers singletons)
+ */
+
+#include "Constants.h"
+#include <string>
+
+namespace bcos::ledger::mpt
+{
+
+Hash32 const& emptyRootHash()
+{
+    static Hash32 const s_value{EMPTY_ROOT_HASH_HEX, Hash32::FromHex};
+    return s_value;
+}
+
+Hash32 const& emptyCodeHash()
+{
+    static Hash32 const s_value{EMPTY_CODE_HASH_HEX, Hash32::FromHex};
+    return s_value;
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Constants.h
+++ b/bcos-ledger/bcos-ledger/mpt/Constants.h
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Constants.h
+ * @brief Ethereum well-known hash constants for the MPT module (spec §5.5)
+ */
+#pragma once
+
+#include "Types.h"
+
+namespace bcos::ledger::mpt
+{
+
+/// Hex string for keccak256(RLP("")) = the empty trie root hash
+constexpr std::string_view EMPTY_ROOT_HASH_HEX =
+    "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421";
+
+/// Hex string for keccak256("") = the empty code hash
+constexpr std::string_view EMPTY_CODE_HASH_HEX =
+    "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+
+/// Returns the singleton Hash32 for the empty trie root.
+/// Initialised from EMPTY_ROOT_HASH_HEX on first call (Meyers singleton).
+Hash32 const& emptyRootHash();
+
+/// Returns the singleton Hash32 for keccak256("") (empty code hash).
+/// Initialised from EMPTY_CODE_HASH_HEX on first call (Meyers singleton).
+Hash32 const& emptyCodeHash();
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Errors.h
+++ b/bcos-ledger/bcos-ledger/mpt/Errors.h
@@ -1,0 +1,36 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Errors.h
+ * @brief Exception types for the MPT module (spec §5.5, §5.2)
+ */
+#pragma once
+
+#include <bcos-utilities/Exceptions.h>
+
+namespace bcos::ledger::mpt
+{
+
+/// Thrown when decoding of HexPrefix or RLP-encoded trie data fails
+DERIVE_BCOS_EXCEPTION(MPTDecodeError);
+
+/// Thrown when an internal MPT invariant is violated (e.g. odd nibble count passed to
+/// nibblesToBytes)
+DERIVE_BCOS_EXCEPTION(MPTInvariantViolation);
+
+/// Thrown when an unexpected BCOS-specific field is encountered in an L2 data structure (spec §5.2)
+DERIVE_BCOS_EXCEPTION(UnexpectedBCOSFieldInL2);
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/HexPrefix.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/HexPrefix.cpp
@@ -1,0 +1,71 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HexPrefix.cpp
+ * @brief Hex-Prefix (compact) encoding implementation per Yellow Paper Appendix C
+ */
+
+#include "HexPrefix.h"
+#include "Errors.h"
+#include <boost/throw_exception.hpp>
+
+namespace bcos::ledger::mpt
+{
+
+bcos::bytes hexPrefixEncode(std::span<uint8_t const> nibbles, bool terminator)
+{
+    bcos::bytes out;
+    bool const odd = (nibbles.size() % 2 == 1);
+    uint8_t firstByte = static_cast<uint8_t>((terminator ? 0x20u : 0x00u) | (odd ? 0x10u : 0x00u));
+    if (odd)
+    {
+        firstByte |= (nibbles[0] & 0x0fu);
+    }
+    out.push_back(firstByte);
+    size_t const start = odd ? 1u : 0u;
+    for (size_t i = start; i + 1 < nibbles.size(); i += 2)
+    {
+        out.push_back(static_cast<bcos::byte>((nibbles[i] << 4u) | (nibbles[i + 1] & 0x0fu)));
+    }
+    return out;
+}
+
+std::pair<std::vector<uint8_t>, bool> hexPrefixDecode(std::span<bcos::byte const> encoded)
+{
+    if (encoded.empty())
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment("hexPrefixDecode: empty input"));
+    }
+    uint8_t const first = encoded[0];
+    bool const terminator = ((first & 0x20u) != 0u);
+    bool const odd = ((first & 0x10u) != 0u);
+
+    std::vector<uint8_t> nibbles;
+    nibbles.reserve((encoded.size() - 1) * 2 + (odd ? 1u : 0u));
+
+    if (odd)
+    {
+        nibbles.push_back(first & 0x0fu);
+    }
+    for (size_t i = 1; i < encoded.size(); ++i)
+    {
+        nibbles.push_back(static_cast<uint8_t>((encoded[i] >> 4u) & 0x0fu));
+        nibbles.push_back(static_cast<uint8_t>(encoded[i] & 0x0fu));
+    }
+    return {std::move(nibbles), terminator};
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/HexPrefix.h
+++ b/bcos-ledger/bcos-ledger/mpt/HexPrefix.h
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HexPrefix.h
+ * @brief Hex-Prefix (compact) encoding per Yellow Paper Appendix C (spec §5.5)
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <cstdint>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace bcos::ledger::mpt
+{
+
+/// Encodes a nibble sequence with a terminator flag using Hex-Prefix encoding.
+///
+/// HP 编码（Yellow Paper Appendix C）首字节布局：
+///   bits [7:6] = 0
+///   bit  5     = terminator flag (1 = leaf, 0 = extension)
+///   bit  4     = 1 when the nibble count is odd
+///   bits [3:0] = first nibble (only meaningful when bit 4 = 1; zero when even)
+///
+/// @param nibbles  Input nibble sequence (each element in [0, 15])
+/// @param terminator  true = leaf node (terminating), false = extension node
+/// @return Compact-encoded byte sequence
+bcos::bytes hexPrefixEncode(std::span<uint8_t const> nibbles, bool terminator);
+
+/// Decodes a Hex-Prefix encoded byte sequence.
+///
+/// @param encoded  Compact-encoded input (must be non-empty)
+/// @return {nibbles, terminator}
+/// @throws MPTDecodeError on empty input
+std::pair<std::vector<uint8_t>, bool> hexPrefixDecode(std::span<bcos::byte const> encoded);
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Nibble.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Nibble.cpp
@@ -1,0 +1,69 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Nibble.cpp
+ * @brief Nibble helper routines implementation
+ */
+
+#include "Nibble.h"
+#include "Errors.h"
+#include <boost/throw_exception.hpp>
+
+namespace bcos::ledger::mpt
+{
+
+std::vector<uint8_t> bytesToNibbles(std::span<bcos::byte const> in)
+{
+    std::vector<uint8_t> out;
+    out.reserve(in.size() * 2);
+    for (bcos::byte b : in)
+    {
+        out.push_back(static_cast<uint8_t>((b >> 4) & 0x0f));
+        out.push_back(static_cast<uint8_t>(b & 0x0f));
+    }
+    return out;
+}
+
+bcos::bytes nibblesToBytes(std::span<uint8_t const> nibbles)
+{
+    if (nibbles.size() % 2 != 0)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
+                                  "nibblesToBytes requires even nibble count"));
+    }
+    bcos::bytes out;
+    out.reserve(nibbles.size() / 2);
+    for (size_t i = 0; i < nibbles.size(); i += 2)
+    {
+        out.push_back(static_cast<bcos::byte>((nibbles[i] << 4) | (nibbles[i + 1] & 0x0f)));
+    }
+    return out;
+}
+
+size_t commonPrefixLen(std::span<uint8_t const> a, std::span<uint8_t const> b) noexcept
+{
+    size_t const maxLen = std::min(a.size(), b.size());
+    size_t i = 0;
+    for (; i < maxLen; ++i)
+    {
+        if (a[i] != b[i])
+        {
+            break;
+        }
+    }
+    return i;
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Nibble.h
+++ b/bcos-ledger/bcos-ledger/mpt/Nibble.h
@@ -1,0 +1,41 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Nibble.h
+ * @brief Nibble (4-bit) helper routines for the MPT module (spec §5.5)
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace bcos::ledger::mpt
+{
+
+/// Splits each byte into two nibbles (high nibble first).
+/// Example: {0xab, 0xcd} -> {0x0a, 0x0b, 0x0c, 0x0d}
+std::vector<uint8_t> bytesToNibbles(std::span<bcos::byte const> in);
+
+/// Merges pairs of nibbles back into bytes (high nibble first).
+/// @throws MPTInvariantViolation when nibbles.size() is odd.
+bcos::bytes nibblesToBytes(std::span<uint8_t const> nibbles);
+
+/// Returns the length of the longest common prefix of two nibble sequences.
+size_t commonPrefixLen(std::span<uint8_t const> a, std::span<uint8_t const> b) noexcept;
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/NodeEncoder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeEncoder.cpp
@@ -1,0 +1,174 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeEncoder.cpp
+ * @brief RLP encoding and NodeRef computation for MPT nodes (spec §5.5)
+ */
+
+#include "NodeEncoder.h"
+#include "HexPrefix.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-utilities/Common.h>
+
+namespace bcos::ledger::mpt
+{
+
+// ---------------------------------------------------------------------------
+// keccak256 — Ethereum-flavour (0x01 domain padding, not NIST 0x06)
+// ---------------------------------------------------------------------------
+
+Hash32 keccak256(std::span<bcos::byte const> in)
+{
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    // bytesConstRef satisfies the TrivialObject Range concept and is the idiomatic input type.
+    hasher.update(bcos::bytesConstRef(in.data(), in.size()));
+    Hash32 out;
+    hasher.final(out);
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Appends the RLP encoding of a NodeRef child into dst.
+// - Default (Inline + empty bytes) → RLP empty string 0x80 (absent child)
+// - Inline non-empty              → splice the raw bytes as-is (already a complete RLP item)
+// - Hash                          → encode the 32-byte hash as an RLP byte-string (33 bytes)
+static void appendChildRef(bcos::bytes& dst, NodeRef const& ref)
+{
+    if (ref.kind == NodeRef::Kind::Inline)
+    {
+        if (ref.inlineBytes.empty())
+        {
+            dst.push_back(0x80);  // RLP empty string = absent child
+        }
+        else
+        {
+            dst.insert(dst.end(), ref.inlineBytes.begin(), ref.inlineBytes.end());
+        }
+    }
+    else
+    {
+        // Hash kind: emit as 33-byte RLP byte-string [0xa0, hash[0..31]]
+        bcos::codec::rlp::encode(dst, ref.hash);
+    }
+}
+
+// Encode EmptyNode → single-byte RLP empty string {0x80}
+static bcos::bytes encodeEmpty(EmptyNode const& /*node*/)
+{
+    return bcos::bytes{0x80};
+}
+
+// Encode LeafNode → RLP list [HP(keyNibbles, leaf=true), value]
+static bcos::bytes encodeLeaf(LeafNode const& node)
+{
+    bcos::bytes out;
+    auto hp = hexPrefixEncode(node.keyNibbles, /*terminator=*/true);
+    // Two-argument encode() wraps in an RLP list automatically.
+    bcos::codec::rlp::encode(out, hp, node.value);
+    return out;
+}
+
+// Encode ExtensionNode → RLP list [HP(sharedNibbles, leaf=false), child_ref_raw]
+// ExtensionNode.child is ALREADY a complete RLP-encoded child reference, so we must
+// splice it raw rather than re-encode it as a byte-string (which would double-wrap).
+static bcos::bytes encodeExtension(ExtensionNode const& node)
+{
+    using namespace bcos::codec::rlp;
+    bcos::bytes out;
+    auto hp = hexPrefixEncode(node.sharedNibbles, /*terminator=*/false);
+    // child contributes its own bytes directly (not as an RLP-wrapped byte-string).
+    const size_t payloadLen = length(hp) + node.child.size();
+    encodeHeader(out, {.isList = true, .payloadLength = payloadLen});
+    encode(out, hp);
+    out.insert(out.end(), node.child.begin(), node.child.end());
+    return out;
+}
+
+// Encode BranchNode → RLP list [child0..child15, value]
+static bcos::bytes encodeBranch(BranchNode const& node)
+{
+    using namespace bcos::codec::rlp;
+
+    // Build the 17-item payload bytes first, then wrap with a list header.
+    bcos::bytes payload;
+    for (NodeRef const& child : node.children)
+    {
+        appendChildRef(payload, child);
+    }
+    // 17th entry: the branch node's own value (empty in most internal nodes)
+    encode(payload, node.value);
+
+    bcos::bytes out;
+    encodeHeader(out, {.isList = true, .payloadLength = payload.size()});
+    out.insert(out.end(), payload.begin(), payload.end());
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// NodeEncoder public API
+// ---------------------------------------------------------------------------
+
+bcos::bytes NodeEncoder::encodeRaw(TrieNode const& node)
+{
+    return std::visit(
+        [](auto const& n) -> bcos::bytes {
+            using T = std::decay_t<decltype(n)>;
+            if constexpr (std::is_same_v<T, EmptyNode>)
+            {
+                return encodeEmpty(n);
+            }
+            else if constexpr (std::is_same_v<T, LeafNode>)
+            {
+                return encodeLeaf(n);
+            }
+            else if constexpr (std::is_same_v<T, ExtensionNode>)
+            {
+                return encodeExtension(n);
+            }
+            else if constexpr (std::is_same_v<T, BranchNode>)
+            {
+                return encodeBranch(n);
+            }
+            else
+            {
+                static_assert(!sizeof(T*), "unhandled TrieNode variant alternative");
+            }
+        },
+        node);
+}
+
+std::pair<bcos::bytes, NodeRef> NodeEncoder::encodeAndRef(TrieNode const& node)
+{
+    bcos::bytes raw = encodeRaw(node);
+    NodeRef ref;
+    if (raw.size() < 32)
+    {
+        ref.kind = NodeRef::Kind::Inline;
+        ref.inlineBytes = raw;
+    }
+    else
+    {
+        ref.kind = NodeRef::Kind::Hash;
+        ref.hash = keccak256(std::span<bcos::byte const>(raw.data(), raw.size()));
+    }
+    return {std::move(raw), std::move(ref)};
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/NodeEncoder.h
+++ b/bcos-ledger/bcos-ledger/mpt/NodeEncoder.h
@@ -1,0 +1,55 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeEncoder.h
+ * @brief RLP encoding and NodeRef computation for MPT nodes (spec §5.5)
+ */
+#pragma once
+
+#include "TrieNode.h"
+#include <bcos-utilities/Common.h>
+#include <span>
+#include <utility>
+
+namespace bcos::ledger::mpt
+{
+
+/// Ethereum-flavour Keccak256 (0x01 padding, NOT NIST SHA3-256 which uses 0x06 padding).
+/// @param in  Raw input bytes (bcos::byte = uint8_t)
+/// @return    32-byte Keccak256 digest
+Hash32 keccak256(std::span<bcos::byte const> in);
+
+/// Encodes MPT nodes to RLP and determines inline-vs-hash node references.
+///
+/// The 32-byte threshold rule (Yellow Paper §D):
+///   len(RLP(node)) <  32 → the node is referenced inline (bytes spliced directly into parent)
+///   len(RLP(node)) >= 32 → the node is referenced by its keccak256 hash
+class NodeEncoder
+{
+public:
+    /// Compute the raw RLP bytes for a TrieNode without making an inline/hash decision.
+    /// EmptyNode  → {0x80}
+    /// LeafNode   → RLP list of [HP(key, leaf=true), value]
+    /// ExtensionNode → RLP list of [HP(key, leaf=false), child_ref_raw]
+    /// BranchNode → RLP list of [child0..child15, value]
+    static bcos::bytes encodeRaw(TrieNode const& node);
+
+    /// Encode a TrieNode and return both the raw RLP and a NodeRef for parent use.
+    ///   If len(raw) <  32: ref.kind = Inline, ref.inlineBytes = raw
+    ///   If len(raw) >= 32: ref.kind = Hash,   ref.hash = keccak256(raw)
+    static std::pair<bcos::bytes, NodeRef> encodeAndRef(TrieNode const& node);
+};
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/TrieNode.h
+++ b/bcos-ledger/bcos-ledger/mpt/TrieNode.h
@@ -1,0 +1,79 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TrieNode.h
+ * @brief In-memory representation of the three MPT node types (spec §5.5)
+ */
+#pragma once
+
+#include "Types.h"
+#include <bcos-utilities/Common.h>
+#include <array>
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+namespace bcos::ledger::mpt
+{
+
+/// The empty trie node — its RLP encoding is the single byte 0x80 (RLP empty string).
+struct EmptyNode
+{
+};
+
+/// A leaf node: stores a path suffix (nibble-space, no terminator) and a value.
+struct LeafNode
+{
+    std::vector<uint8_t> keyNibbles;  ///< Nibble sequence (no HP terminator; each in [0, 15])
+    bcos::bytes value;                ///< Raw value bytes (encoded as RLP byte-string)
+};
+
+/// An extension node: stores a shared nibble prefix and an already-RLP-encoded child reference.
+struct ExtensionNode
+{
+    std::vector<uint8_t> sharedNibbles;  ///< Shared nibble prefix (no HP terminator)
+    bcos::bytes child;  ///< Already RLP-encoded child ref (inline bytes or 33-byte hash string)
+};
+
+/// A node reference used inside BranchNode children.
+/// - Inline: the referenced subtree's complete RLP encoding is short (<32 bytes) and is stored
+///   directly; inlineBytes may be empty, which represents an absent child (treated as empty).
+/// - Hash:   the referenced subtree is ≥32 bytes; only the 32-byte keccak256 digest is stored.
+struct NodeRef
+{
+    enum class Kind
+    {
+        Inline,
+        Hash
+    };
+
+    Kind kind{Kind::Inline};
+    bcos::bytes inlineBytes;  ///< Valid when kind == Inline. An empty inlineBytes
+                              ///< with kind == Inline encodes as RLP-empty (0x80) and
+                              ///< represents an absent branch child.
+    Hash32 hash{};            ///< Valid when kind == Hash; keccak256(child RLP)
+};
+
+/// A branch node: 16 child references (one per hex nibble) plus an optional value.
+struct BranchNode
+{
+    std::array<NodeRef, 16> children;  ///< Default-constructed = Inline + empty (absent child)
+    bcos::bytes value;                 ///< Typically empty for internal branch nodes
+};
+
+/// Tagged union of all MPT node types.
+using TrieNode = std::variant<EmptyNode, LeafNode, ExtensionNode, BranchNode>;
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Types.h
+++ b/bcos-ledger/bcos-ledger/mpt/Types.h
@@ -1,0 +1,32 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Types.h
+ * @brief Type aliases for the MPT module (spec §5.5)
+ */
+#pragma once
+
+#include <bcos-utilities/FixedBytes.h>
+
+namespace bcos::ledger::mpt
+{
+
+/// 32-byte hash type used throughout the MPT (= keccak256 digest size)
+using Hash32 = bcos::h256;
+
+/// 20-byte Ethereum account address
+using Address20 = bcos::h160;
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/test/unittests/mpt/HexPrefixTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/HexPrefixTest.cpp
@@ -1,0 +1,93 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HexPrefixTest.cpp
+ * @brief Unit tests for Hex-Prefix encoding (Yellow Paper Appendix C vectors)
+ */
+
+#include "bcos-ledger/mpt/HexPrefix.h"
+#include "bcos-ledger/mpt/Errors.h"
+#include <boost/test/unit_test.hpp>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(HexPrefixSuite)
+
+// Yellow Paper Appendix C standard vector: even count, no terminator
+// nibbles={0,1,2,3,4,5}, term=false -> {0x00, 0x01, 0x23, 0x45}
+BOOST_AUTO_TEST_CASE(EncodeEvenNoTerminator)
+{
+    std::vector<uint8_t> const nibbles{0, 1, 2, 3, 4, 5};
+    bcos::bytes const expected{0x00, 0x01, 0x23, 0x45};
+    auto const result = hexPrefixEncode(nibbles, false);
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+}
+
+// Yellow Paper Appendix C standard vector: odd count, no terminator
+// nibbles={1,2,3,4,5}, term=false -> {0x11, 0x23, 0x45}
+BOOST_AUTO_TEST_CASE(EncodeOddNoTerminator)
+{
+    std::vector<uint8_t> const nibbles{1, 2, 3, 4, 5};
+    bcos::bytes const expected{0x11, 0x23, 0x45};
+    auto const result = hexPrefixEncode(nibbles, false);
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+}
+
+// Yellow Paper Appendix C standard vector: even count, with terminator
+// nibbles={0,1,2,3,4,5}, term=true -> {0x20, 0x01, 0x23, 0x45}
+BOOST_AUTO_TEST_CASE(EncodeEvenWithTerminator)
+{
+    std::vector<uint8_t> const nibbles{0, 1, 2, 3, 4, 5};
+    bcos::bytes const expected{0x20, 0x01, 0x23, 0x45};
+    auto const result = hexPrefixEncode(nibbles, true);
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+}
+
+// Yellow Paper Appendix C standard vector: odd count, with terminator
+// nibbles={1,2,3,4,5}, term=true -> {0x31, 0x23, 0x45}
+BOOST_AUTO_TEST_CASE(EncodeOddWithTerminator)
+{
+    std::vector<uint8_t> const nibbles{1, 2, 3, 4, 5};
+    bcos::bytes const expected{0x31, 0x23, 0x45};
+    auto const result = hexPrefixEncode(nibbles, true);
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+}
+
+// Round-trip for both terminator values
+BOOST_AUTO_TEST_CASE(EncodeDecodeRoundTrip)
+{
+    std::vector<uint8_t> const nibbles{0x0a, 0x0b, 0x0c, 0x0d, 0x0e};
+
+    for (bool term : {false, true})
+    {
+        auto const encoded = hexPrefixEncode(nibbles, term);
+        auto const [decoded, decodedTerm] = hexPrefixDecode(encoded);
+        BOOST_CHECK_EQUAL(decodedTerm, term);
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            decoded.begin(), decoded.end(), nibbles.begin(), nibbles.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DecodeEmptyThrows)
+{
+    bcos::bytes const empty{};
+    BOOST_CHECK_THROW(hexPrefixDecode(empty), MPTDecodeError);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/NibbleTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/NibbleTest.cpp
@@ -1,0 +1,82 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NibbleTest.cpp
+ * @brief Unit tests for Nibble helpers (spec §5.5)
+ */
+
+#include "bcos-ledger/mpt/Nibble.h"
+#include "bcos-ledger/mpt/Errors.h"
+#include <boost/test/unit_test.hpp>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(NibbleSuite)
+
+BOOST_AUTO_TEST_CASE(BytesToNibblesEvenLength)
+{
+    bcos::bytes const input{0xab, 0xcd};
+    std::vector<uint8_t> const expected{0x0a, 0x0b, 0x0c, 0x0d};
+    auto const result = bytesToNibbles(input);
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(NibblesToBytesRoundTripEvenOnly)
+{
+    std::vector<uint8_t> const input{0x01, 0x02, 0x03, 0x04};
+    bcos::bytes const expected{0x12, 0x34};
+    auto const result = nibblesToBytes(input);
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(CommonPrefixBasic)
+{
+    std::vector<uint8_t> const a{0x01, 0x02, 0x0a, 0x0b};
+    std::vector<uint8_t> const b{0x01, 0x02, 0x0c, 0x0d};
+    BOOST_CHECK_EQUAL(commonPrefixLen(a, b), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(NibblesToBytesOddThrows)
+{
+    std::vector<uint8_t> const odd{0x01, 0x02, 0x03};
+    BOOST_CHECK_THROW(nibblesToBytes(odd), MPTInvariantViolation);
+}
+
+BOOST_AUTO_TEST_CASE(BytesToNibblesRoundTrip)
+{
+    bcos::bytes const input{0x12, 0x34, 0x56, 0x78};
+    auto const nibbles = bytesToNibbles(input);
+    auto const roundTrip = nibblesToBytes(nibbles);
+    BOOST_CHECK_EQUAL_COLLECTIONS(roundTrip.begin(), roundTrip.end(), input.begin(), input.end());
+}
+
+BOOST_AUTO_TEST_CASE(CommonPrefixEmpty)
+{
+    std::vector<uint8_t> const a{};
+    std::vector<uint8_t> const b{0x01};
+    BOOST_CHECK_EQUAL(commonPrefixLen(a, b), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(CommonPrefixIdentical)
+{
+    std::vector<uint8_t> const a{0x01, 0x02, 0x03};
+    BOOST_CHECK_EQUAL(commonPrefixLen(a, a), 3u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/NodeEncoderTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/NodeEncoderTest.cpp
@@ -1,0 +1,143 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeEncoderTest.cpp
+ * @brief Unit tests for TrieNode RLP encoding and NodeRef computation (spec §5.5)
+ */
+
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/NodeEncoder.h>
+#include <bcos-ledger/mpt/TrieNode.h>
+#include <bcos-utilities/Common.h>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::test
+{
+
+BOOST_AUTO_TEST_SUITE(NodeEncoderSuite)
+
+// ---------------------------------------------------------------------------
+// Test 1: Short leaf → inline node reference
+// ---------------------------------------------------------------------------
+// LeafNode{keyNibbles={1,2,3,4}, value={0xaa}}
+//   HP(keyNibbles=[1,2,3,4], leaf=true): even count → [0x20, 0x12, 0x34] (3 bytes)
+//   RLP list [ 3-byte hp, 1-byte value ] payload = 4 + 2 = 6 bytes → total 7 bytes
+//   7 < 32, so encodeAndRef must return Inline
+BOOST_AUTO_TEST_CASE(EncodeLeafShort)
+{
+    using namespace bcos::ledger::mpt;
+
+    LeafNode leaf;
+    leaf.keyNibbles = {1, 2, 3, 4};
+    leaf.value = bcos::bytes{0xaa};
+
+    auto [raw, ref] = NodeEncoder::encodeAndRef(TrieNode{leaf});
+
+    BOOST_CHECK(!raw.empty());
+    BOOST_CHECK(raw.size() < 32);
+    BOOST_CHECK(ref.kind == NodeRef::Kind::Inline);
+    BOOST_CHECK(ref.inlineBytes == raw);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Large branch node → hash node reference
+// ---------------------------------------------------------------------------
+// The plan claimed a default BranchNode is "always hashed due to size", which is incorrect:
+// 16 × 0x80 (absent) + 0x80 (empty value) = 17 bytes payload → 1 byte header → 18 bytes total
+// (< 32, so inline).  The test is adapted: we set children[0] to a Hash-kind NodeRef with a
+// 32-byte hash digest.  That child contributes [0xa0, hash×32] = 33 bytes, making the payload
+// at least 33 + 15 + 1 = 49 bytes → total ≥ 50 bytes (> 32) → encodeAndRef returns Hash.
+BOOST_AUTO_TEST_CASE(EncodeBranchHashedWhenLarge)
+{
+    using namespace bcos::ledger::mpt;
+
+    BranchNode branch;
+    // Set children[0] to a Hash-kind ref with a dummy 32-byte hash
+    branch.children[0].kind = NodeRef::Kind::Hash;
+    branch.children[0].hash =
+        Hash32("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+    auto [raw, ref] = NodeEncoder::encodeAndRef(TrieNode{branch});
+
+    // 33 (hash child) + 15 × 1 (absent children) + 1 (empty value) = 49 payload → 50 total
+    BOOST_CHECK(raw.size() >= 32);
+    BOOST_CHECK(ref.kind == NodeRef::Kind::Hash);
+    // Hash must be exactly 32 bytes
+    BOOST_CHECK_EQUAL(ref.hash.size(), 32u);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Empty trie root matches Ethereum well-known constant
+// ---------------------------------------------------------------------------
+// EmptyNode encodes to RLP empty string {0x80} (1 byte, < 32 → inline).
+// keccak256({0x80}) must equal the well-known Ethereum empty-trie root:
+//   0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+// This test validates that the OpenSSLHasher applies the Ethereum 0x01 domain padding,
+// not the NIST SHA3-256 0x06 padding.
+BOOST_AUTO_TEST_CASE(EmptyTrieRootMatchesEthereumConstant)
+{
+    using namespace bcos::ledger::mpt;
+
+    bcos::bytes raw = NodeEncoder::encodeRaw(TrieNode{EmptyNode{}});
+    BOOST_CHECK_EQUAL(raw.size(), 1u);
+    BOOST_CHECK_EQUAL(raw[0], 0x80u);
+
+    Hash32 digest = keccak256(std::span<bcos::byte const>(raw.data(), raw.size()));
+    BOOST_CHECK_EQUAL(digest, emptyRootHash());
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Inline / hash threshold at 32 bytes
+// ---------------------------------------------------------------------------
+// Using keyNibbles={1,2,3,4} (HP = [0x20,0x12,0x34], 3 bytes; RLP(hp)=4 bytes):
+//   value = bytes(25, 0xff): RLP(value) = 1+25 = 26 bytes
+//     payload = 4+26 = 30, list = 1+30 = 31 bytes < 32  → Inline
+//   value = bytes(26, 0xff): RLP(value) = 1+26 = 27 bytes
+//     payload = 4+27 = 31, list = 1+31 = 32 bytes >= 32 → Hash
+BOOST_AUTO_TEST_CASE(InlineThresholdAt31Bytes)
+{
+    using namespace bcos::ledger::mpt;
+
+    std::vector<uint8_t> const key = {1, 2, 3, 4};
+
+    // 31-byte encoding → Inline
+    {
+        LeafNode leaf;
+        leaf.keyNibbles = key;
+        leaf.value = bcos::bytes(25, 0xff);
+
+        auto [raw, ref] = NodeEncoder::encodeAndRef(TrieNode{leaf});
+        BOOST_CHECK_EQUAL(raw.size(), 31u);
+        BOOST_CHECK(ref.kind == NodeRef::Kind::Inline);
+        BOOST_CHECK(ref.inlineBytes == raw);
+    }
+
+    // 32-byte encoding → Hash
+    {
+        LeafNode leaf;
+        leaf.keyNibbles = key;
+        leaf.value = bcos::bytes(26, 0xff);
+
+        auto [raw, ref] = NodeEncoder::encodeAndRef(TrieNode{leaf});
+        BOOST_CHECK_EQUAL(raw.size(), 32u);
+        BOOST_CHECK(ref.kind == NodeRef::Kind::Hash);
+        BOOST_CHECK_EQUAL(ref.hash.size(), 32u);
+        BOOST_CHECK(ref.inlineBytes.empty());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test


### PR DESCRIPTION
## Summary
- Adds the RLP encoding layer for the MPT module:
  - `TrieNode.h` — `variant<EmptyNode, LeafNode, ExtensionNode, BranchNode>` plus `NodeRef { kind: Inline | Hash, inlineBytes, hash }`. A default-constructed child (`Inline` + empty `inlineBytes`) is the explicit "absent" state and encodes as RLP-empty (`0x80`).
  - `NodeEncoder.{h,cpp}` — `encodeRaw(TrieNode)` produces canonical Ethereum RLP for each node kind; `encodeAndRef(TrieNode)` returns `(raw bytes, NodeRef)` with the spec's `<32B inline / >=32B hash` boundary. Visitor uses `if constexpr` with a `static_assert(!sizeof(T*), ...)` fallback to force a compile error if a new `TrieNode` alternative is added without an explicit handler.
  - `keccak256(span<bcos::byte const>)` free function wrapping `bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher` (Ethereum 0x01 padding, not NIST SHA3-256's 0x06).
- Adds `bcos-crypto` to `ledger`'s `target_link_libraries` so the hasher is reachable from the library.

## Stacking
- **Base**: `feat/mpt-pr03-nibble-types` (this is a stacked PR in the fork — it depends on M2.1).
- **Upstream PR for the M2.1 dependency**: FISCO-BCOS/FISCO-BCOS#5198.
- After PR #5198 merges, this branch will be rebased `--onto release-3.18.0` and a fresh PR opened against upstream.

## Test plan
- [x] `./bcos-ledger/test/test-bcos-ledger --run_test=NodeEncoderSuite` — 4 cases:
  - `EncodeLeafShort` — short leaf produces `Inline` ref with `inlineBytes == raw`
  - `EncodeBranchHashedWhenLarge` — branch carrying a 32-byte hash child crosses the inline boundary and yields `Hash` ref
  - `EmptyTrieRootMatchesEthereumConstant` — `keccak256(encodeRaw(EmptyNode{})) == emptyRootHash()` validates the Keccak 0x01-padding patch (proves the hasher is Ethereum-flavoured, not NIST SHA3-256)
  - `InlineThresholdAt31Bytes` — leaf encoded at exactly 31 bytes → `Inline`; at exactly 32 bytes → `Hash`
- [x] Regression: `NibbleSuite` (7) and `HexPrefixSuite` (6) from M2.1 still green
- [x] `clang-format --dry-run --Werror` clean on all new files
- [x] License header in the first 20 lines of each new file